### PR TITLE
New portable timed scheduler

### DIFF
--- a/src/future.cpp
+++ b/src/future.cpp
@@ -17,6 +17,7 @@
 #if STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_PORTABLE
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <memory>
@@ -95,12 +96,32 @@ public:
 
 /**************************************************************************************************/
 
+struct greater_first
+{
+    using result_type = bool;
+
+    template <typename T>
+    bool operator()(const T& x, const T& y) {
+        return x.first > y.first;
+    }
+};
+
 class task_system 
 {
     const unsigned              _count{thread::hardware_concurrency()};
     vector<thread>              _threads;
     vector<notification_queue>  _q{_count};
     atomic<unsigned>            _index{0};
+
+    using element_t = pair<chrono::system_clock::time_point, function<void()>>;
+    using queue_t = vector<element_t>;
+
+    queue_t             _timed_queue;
+    condition_variable  _condition;
+    bool                _stop = false;
+    mutex               _timed_queue_mutex;
+    thread              _timed_queue_thread;
+
     
     void run(unsigned i) {
         while (true) {
@@ -114,15 +135,44 @@ class task_system
             f();
         }
     }
-    
-  public:
+
+    void timed_queue_run() {
+        while (true) {
+            function<void()> task;
+            {
+                lock_t lock(_timed_queue_mutex);
+
+                while (_timed_queue.empty() && !_stop) _condition.wait(lock);
+                if (_stop) break;
+                while (chrono::system_clock::now() < _timed_queue.front().first) {
+                    auto when = _timed_queue.front().first;
+                    _condition.wait_until(lock, when);
+                }
+                pop_heap(begin(_timed_queue), end(_timed_queue), greater_first());
+                task = move(_timed_queue.back().second);
+                _timed_queue.pop_back();
+            }
+
+            async_(move(task));
+        }
+    }
+
+public:
     task_system() {
         for (unsigned n = 0; n != _count; ++n) {
             _threads.emplace_back([&, n]{ run(n); });
         }
+        _timed_queue_thread = thread([this] { this->timed_queue_run(); });
     }
     
     ~task_system() {
+        {
+            lock_t lock(_timed_queue_mutex);
+            _stop = true;
+        }
+        _condition.notify_one();
+        _timed_queue_thread.join();
+
         for (auto& e : _q) e.done();
         for (auto& e : _threads) e.join();
     }
@@ -138,78 +188,16 @@ class task_system
         _q[i % _count].push(forward<F>(f));
     }
 
-    // TODO FP: delayed execution to be implemented
     template <typename F>
-    void async_(std::chrono::system_clock::time_point, F&& f) {
-        auto i = _index++;
-
-        for (unsigned n = 0; n != _count; ++n) {
-            if (_q[(i + n) % _count].try_push(forward<F>(f))) return;
-        }
-
-        _q[i % _count].push(forward<F>(f));
-    }
-};
-
-/**************************************************************************************************/
-
-#if 0
-struct timed_queue 
-{
-    using lock_t = unique_lock<mutex>;
-    using element_t = pair<steady_clock::time_point, any_packaged_task_>;
-    using queue_t = vector<element_t>;
-
-    queue_t             _q;
-    condition_variable  _condition;
-    bool                _done = false;
-    mutex               _mutex;
-    thread              _thread;
-
-    timed_queue() { _thread = thread([this]{ this->_run(); }); }
-
-    ~timed_queue() {
+    void async_(std::chrono::system_clock::time_point when, F&& f) {
         {
-        lock_t lock(_mutex);
-        _done = true;
-        }
-        _thread.join();
-    }
-
-    void _run()
-    {
-        while(true) {
-            any_packaged_task_ task;
-            {
-            lock_t lock(_mutex);
-
-            while (_q.empty() && !_done) _condition.wait(lock);
-            if (_q.empty()) break; // ==> _done
-            while (steady_clock::now() < _q.front().first) {
-                auto t = _q.front().first;
-                _condition.wait_until(lock, t);
-            }
-            pop_heap(begin(_q), end(_q), [](const auto& x, const auto& y) {
-                return x.first > y.first;
-            });
-            task = move(_q.back().second);
-            _q.pop_back();
-            }
-
-            adobe::details::async_(move(task));
-        }
-    }
-
-    void async(const steady_clock::time_point& when, any_packaged_task_&& p) {
-        {
-        lock_t lock(_mutex);
-        _q.push_back(element_t(when, move(p)));
-        push_heap(begin(_q), end(_q), greater_first());
+            lock_t lock(_timed_queue_mutex);
+            _timed_queue.emplace_back(when, std::forward<F>(f));
+            push_heap(begin(_timed_queue), end(_timed_queue), greater_first());
         }
         _condition.notify_one();
     }
 };
-#endif
 
 /**************************************************************************************************/
 #endif

--- a/stlab/channel.hpp
+++ b/stlab/channel.hpp
@@ -17,6 +17,14 @@
 
 #include <stlab/future.hpp>
 
+#ifdef max
+#undef max
+#endif
+
+#ifdef min
+#undef min
+#endif
+
 /**************************************************************************************************/
 
 namespace stlab {

--- a/stlab/channel.hpp
+++ b/stlab/channel.hpp
@@ -416,7 +416,7 @@ struct shared_process : shared_process_receiver<yield_type<T, Arg>>,
         if (state == process_state::yield) {
             if (when <= now) broadcast(_process.yield());
             else _scheduler(when, [_this = this->shared_from_this()] {
-                _this->broadcast(_process.yield());
+                _this->broadcast(_this->_process.yield());
             });
         }
         

--- a/stlab/future.hpp
+++ b/stlab/future.hpp
@@ -29,6 +29,8 @@
 #include <ppapi/cpp/module.h>
 #include <ppapi/cpp/core.h>
 #include <ppapi/cpp/completion_callback.h>
+#elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_WINDOWS
+#include <Windows.h>
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_PORTABLE
 // REVISIT (sparent) : for testing only
 #if 0 && __APPLE__
@@ -1452,8 +1454,6 @@ using main_scheduler = default_scheduler;
     || (STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_PNACL) \
     || (STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_WINDOWS)
 
-// REVISIT (sparent): Since we are using the default threadpool, can the windows default scheduler
-// just be inlined here?
 
 struct default_scheduler {
     using result_type = void;
@@ -1487,6 +1487,78 @@ struct main_scheduler {
                 delete f;
             }, new f_t(std::move(f))), 0);
     }
+};
+
+#elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_WINDOWS
+
+inline FILETIME time_point_to_FILETIME(const std::chrono::system_clock::time_point& tp) {
+    FILETIME ft = { 0, 0 };
+    SYSTEMTIME st = { 0 };
+    time_t t = std::chrono::system_clock::to_time_t(tp);
+    tm utc_tm;
+    if (!gmtime_s(&utc_tm, &t)) {
+        st.wSecond = static_cast<WORD>(utc_tm.tm_sec);
+        st.wMinute = static_cast<WORD>(utc_tm.tm_min);
+        st.wHour = static_cast<WORD>(utc_tm.tm_hour);
+        st.wDay = static_cast<WORD>(utc_tm.tm_mday);
+        st.wMonth = static_cast<WORD>(utc_tm.tm_mon + 1);
+        st.wYear = static_cast<WORD>(utc_tm.tm_year + 1900);
+        st.wMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count() % 1000;
+        SystemTimeToFileTime(&st, &ft);
+    }
+    return ft;
+}
+
+
+class task_system
+{
+public:
+    template <typename F>
+    void async_(F&& f) {
+        auto work = CreateThreadpoolWork(&callback_impl<F>,
+            new F(std::forward<F>(f)),
+            nullptr);
+        if (work == nullptr) {
+            throw std::bad_alloc();
+        }
+        SubmitThreadpoolWork(work);
+    }
+
+    template <typename F>
+    void async_(std::chrono::system_clock::time_point time_point, F&& f) {
+
+        auto timer = CreateThreadpoolTimer(&timer_callback_impl<F>,
+            new F(std::forward<F>(f)),
+            nullptr);
+        if (timer == nullptr) {
+            throw std::bad_alloc();
+        }
+
+        auto file_time = time_point_to_FILETIME(time_point);
+
+        SetThreadpoolTimer(timer,
+            &file_time,
+            0,
+            0);
+    }
+private:
+
+    template <typename F>
+    static void CALLBACK callback_impl(PTP_CALLBACK_INSTANCE /*instance*/,
+        PVOID                 parameter,
+        PTP_WORK              /*Work*/) {
+        std::unique_ptr<F> f(static_cast<F*>(parameter));
+        (*f)();
+    }
+
+    template <typename F>
+    static void CALLBACK timer_callback_impl(PTP_CALLBACK_INSTANCE /*Instance*/,
+        PVOID                 parameter,
+        PTP_TIMER             /*timer*/) {
+        std::unique_ptr<F> f(static_cast<F*>(parameter));
+        (*f)();
+    }
+
 };
 
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_PORTABLE

--- a/stlab/future.hpp
+++ b/stlab/future.hpp
@@ -1459,8 +1459,8 @@ struct default_scheduler {
     using result_type = void;
 
     template <typename F>
-    void operator()(std::chrono::system_clock::time_point delay, F f) {
-        detail::async_(delay, std::move(f));
+    void operator()(std::chrono::system_clock::time_point when, F f) {
+        detail::async_(when, std::move(f));
     }
 
     template <typename F>
@@ -1491,25 +1491,6 @@ struct main_scheduler {
 
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_WINDOWS
 
-inline FILETIME time_point_to_FILETIME(const std::chrono::system_clock::time_point& tp) {
-    FILETIME ft = { 0, 0 };
-    SYSTEMTIME st = { 0 };
-    time_t t = std::chrono::system_clock::to_time_t(tp);
-    tm utc_tm;
-    if (!gmtime_s(&utc_tm, &t)) {
-        st.wSecond = static_cast<WORD>(utc_tm.tm_sec);
-        st.wMinute = static_cast<WORD>(utc_tm.tm_min);
-        st.wHour = static_cast<WORD>(utc_tm.tm_hour);
-        st.wDay = static_cast<WORD>(utc_tm.tm_mday);
-        st.wMonth = static_cast<WORD>(utc_tm.tm_mon + 1);
-        st.wYear = static_cast<WORD>(utc_tm.tm_year + 1900);
-        st.wMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count() % 1000;
-        SystemTimeToFileTime(&st, &ft);
-    }
-    return ft;
-}
-
-
 class task_system
 {
 public:
@@ -1525,7 +1506,7 @@ public:
     }
 
     template <typename F>
-    void async_(std::chrono::system_clock::time_point time_point, F&& f) {
+    void async_(std::chrono::system_clock::time_point when, F&& f) {
 
         auto timer = CreateThreadpoolTimer(&timer_callback_impl<F>,
             new F(std::forward<F>(f)),
@@ -1534,7 +1515,7 @@ public:
             throw std::bad_alloc();
         }
 
-        auto file_time = time_point_to_FILETIME(time_point);
+        auto file_time = time_point_to_FILETIME(when);
 
         SetThreadpoolTimer(timer,
             &file_time,
@@ -1559,6 +1540,23 @@ private:
         (*f)();
     }
 
+    FILETIME time_point_to_FILETIME(const std::chrono::system_clock::time_point& when) {
+        FILETIME ft = { 0, 0 };
+        SYSTEMTIME st = { 0 };
+        time_t t = std::chrono::system_clock::to_time_t(when);
+        tm utc_tm;
+        if (!gmtime_s(&utc_tm, &t)) {
+            st.wSecond = static_cast<WORD>(utc_tm.tm_sec);
+            st.wMinute = static_cast<WORD>(utc_tm.tm_min);
+            st.wHour = static_cast<WORD>(utc_tm.tm_hour);
+            st.wDay = static_cast<WORD>(utc_tm.tm_mday);
+            st.wMonth = static_cast<WORD>(utc_tm.tm_mon + 1);
+            st.wYear = static_cast<WORD>(utc_tm.tm_year + 1900);
+            st.wMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(when.time_since_epoch()).count() % 1000;
+            SystemTimeToFileTime(&st, &ft);
+        }
+        return ft;
+    }
 };
 
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_PORTABLE


### PR DESCRIPTION
My old PR for for branch PortableTimedScheduler should be deleted. I brought all changes for this to a new branch that has the develop branch as source. So this contains now the code movement of the Windows Thread pool code from future.cpp into the future.hpp and the portable timed scheduler.
Your recent comment regarding immediately scheduling a task which time_point is equal to time_point::min() was added.
In this regard I noticed that for the timed scheduler in the libdispatch implementation you compare against time_point() and not against time_point::min(). 