### PR TITLE
Vs scope workaround

### DIFF
--- a/stlab/concurrency/main_executor.hpp
+++ b/stlab/concurrency/main_executor.hpp
@@ -97,7 +97,8 @@ struct main_executor_type
 
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_WINDOWS
 
-// TODO main_executor_type for Windows 8 / 10
+struct main_executor_type
+{};
 
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_PORTABLE
 

--- a/stlab/concurrency/main_executor.hpp
+++ b/stlab/concurrency/main_executor.hpp
@@ -97,6 +97,7 @@ struct main_executor_type
 
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_WINDOWS
 
+// TODO main_executor_type for Windows 8 / 10
 struct main_executor_type
 {};
 

--- a/stlab/scope.hpp
+++ b/stlab/scope.hpp
@@ -46,6 +46,14 @@ inline auto scope(Args&&... args) {
                                  std::make_index_sequence<sizeof...(args) - 1>());
 }
 
+/* Workaround until VS2017 bug is fixed */
+template <typename T, typename F>
+inline auto scope(std::mutex& m, F&& f) {
+    T scoped(m);
+    return std::forward<F>(f)();
+}
+
+
 /**************************************************************************************************/
 
 } // namespace v1


### PR DESCRIPTION
This implements a workaround for the bug in Visual Studio 2015/2017 compiler in the scope function. I tried several way to do it with a variadic template, but without success. Currently we only use it with one argument, so this should work for the moment.