### PR TITLE
Add AppVeyor integration for Windows CI builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ install:
   - python --version
 
   ############################################################################
-  # Install Python
+  # Install conan
   ############################################################################
   - pip install conan
 
@@ -49,8 +49,6 @@ install:
   - set PATH=C:\projects\deps\cmake\bin;%PATH%
   - cmake --version
 
-
-
 before_build:
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - cd C:\projects\libraries
@@ -60,6 +58,5 @@ build_script:
   - setup_msvc_debug.bat
   - cd build_debug
   - cmake --build .
-  - stlab.test.future.test
-  - stlab.test.serial_queue.test
-  
+  - test\Debug\stlab.test.future.test
+  - test\Debug\stlab.test.serial_queue.test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,13 +26,18 @@ install:
   - cd C:\projects\deps
 
   ############################################################################
-  # Install Ninja
+  # Install Python
   ############################################################################
-  - set NINJA_URL="https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-win.zip"
-  - appveyor DownloadFile %NINJA_URL% -FileName ninja.zip
-  - 7z x ninja.zip -oC:\projects\deps\ninja > nul
-  - set PATH=C:\projects\deps\ninja;%PATH%
-  - ninja --version
+  - set PYTHON_URL="https://www.python.org/ftp/python/3.6.2/python-3.6.2-embed-amd64.zip"
+  - appveyor DownloadFile %PYTHON_URL% -FileName python.zip
+  - 7z x python.zip -oC:\projects\deps\python > nul
+  - set PATH=C:\projects\deps\python;%PATH%
+  - python --version
+
+  ############################################################################
+  # Install Python
+  ############################################################################
+  - pip install conan
 
   ############################################################################
   # Install a recent CMake
@@ -45,13 +50,16 @@ install:
   - cmake --version
 
 
+
 before_build:
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - cd C:\projects\libraries
 
 
 build_script:
-  - mkdir build
-  - cd build
-  - cmake .. -GNinja -DCMAKE_CXX_COMPILER=cl
-  - cmake --build . --target stlab.test.future.test
+  - setup_msvc_debug.bat
+  - cd build_debug
+  - cmake --build .
+  - stlab.test.future.test
+  - stlab.test.serial_queue.test
+  

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,57 @@
+# Copyright 2015 Adobe
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+# Based on a version by Louis Dionne
+
+shallow_clone: true
+
+os:
+  - Visual Studio 2015
+
+build:
+  verbosity: detailed
+
+configuration:
+  - Debug
+
+branches:
+  except:
+    - /pr\/.+/
+
+install:
+  ############################################################################
+  # All external dependencies are installed in C:\projects\deps
+  ############################################################################
+  - mkdir C:\projects\deps
+  - cd C:\projects\deps
+
+  ############################################################################
+  # Install Ninja
+  ############################################################################
+  - set NINJA_URL="https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-win.zip"
+  - appveyor DownloadFile %NINJA_URL% -FileName ninja.zip
+  - 7z x ninja.zip -oC:\projects\deps\ninja > nul
+  - set PATH=C:\projects\deps\ninja;%PATH%
+  - ninja --version
+
+  ############################################################################
+  # Install a recent CMake
+  ############################################################################
+  - set CMAKE_URL="https://cmake.org/files/v3.8/cmake-3.8.0-win64-x64.zip"
+  - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
+  - 7z x cmake.zip -oC:\projects\deps > nul
+  - move C:\projects\deps\cmake-* C:\projects\deps\cmake # Move to a version-agnostic directory
+  - set PATH=C:\projects\deps\cmake\bin;%PATH%
+  - cmake --version
+
+
+before_build:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+  - cd C:\projects\libraries
+
+
+build_script:
+  - mkdir build
+  - cd build
+  - cmake .. -GNinja -DCMAKE_CXX_COMPILER=cl
+  - cmake --build . --target stlab.test.future.test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,5 +58,5 @@ build_script:
   - setup_msvc_debug.bat
   - cd build_debug
   - cmake --build .
-  - test\Debug\stlab.test.future.test
-  - test\Debug\stlab.test.serial_queue.test
+  - bin\stlab.test.future.test --log_level=message
+  - bin\stlab.test.serial_queue.test.exe

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ASL libraries will be migrated here in the stlab namespace, new libraries will b
 - **`master`:** [![Master status](https://travis-ci.org/stlab/libraries.svg?branch=master)](https://travis-ci.org/stlab/libraries) [![Code Coverage](https://codecov.io/github/stlab/libraries/coverage.svg?branch=master)](https://codecov.io/gh/stlab/libraries/branch/master)
 
 - **`develop`:** [![Travis status](https://travis-ci.org/stlab/libraries.svg?branch=develop)](https://travis-ci.org/stlab/libraries)
-[![Appveyor status](https://ci.appveyor.com/project/FelixPetriconi/libraries)][![Code Coverage](https://codecov.io/github/stlab/libraries/coverage.svg?branch=develop)](https://codecov.io/gh/stlab/libraries/branch/develop)
+[![AppVeyor status](https://ci.appveyor.com/api/projects/status/github/FelixPetriconi/libraries)][![Code Coverage](https://codecov.io/github/stlab/libraries/coverage.svg?branch=develop)](https://codecov.io/gh/stlab/libraries/branch/develop)
 
 
 # Content

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ ASL libraries will be migrated here in the stlab namespace, new libraries will b
 
 - **`master`:** [![Master status](https://travis-ci.org/stlab/libraries.svg?branch=master)](https://travis-ci.org/stlab/libraries) [![Code Coverage](https://codecov.io/github/stlab/libraries/coverage.svg?branch=master)](https://codecov.io/gh/stlab/libraries/branch/master)
 
-- **`develop`:** [![Develop status](https://travis-ci.org/stlab/libraries.svg?branch=develop)](https://travis-ci.org/stlab/libraries)
-[![Code Coverage](https://codecov.io/github/stlab/libraries/coverage.svg?branch=develop)](https://codecov.io/gh/stlab/libraries/branch/develop)
+- **`develop`:** [![Travis status](https://travis-ci.org/stlab/libraries.svg?branch=develop)](https://travis-ci.org/stlab/libraries)
+[![Appveyor status](https://ci.appveyor.com/project/FelixPetriconi/libraries)][![Code Coverage](https://codecov.io/github/stlab/libraries/coverage.svg?branch=develop)](https://codecov.io/gh/stlab/libraries/branch/develop)
+
 
 # Content
 


### PR DESCRIPTION
This adds a new badge to our main page. It displays the status of a build with Visual Studio 2015.
Currently this takes the status from my fork. @sean-parent or @fosterbrereton , could you create from the stlab organization an account into AppVeyor.