### PR TITLE
Changing all chrono::system_clock to chrono::steady_clock

### DIFF
--- a/stlab/concurrency/channel.hpp
+++ b/stlab/concurrency/channel.hpp
@@ -61,13 +61,13 @@ enum class message_t { argument, error };
 
 /**************************************************************************************************/
 
-using process_state_scheduled = std::pair<process_state, std::chrono::system_clock::time_point>;
+using process_state_scheduled = std::pair<process_state, std::chrono::steady_clock::time_point>;
 
 constexpr process_state_scheduled await_forever{process_state::await,
-                                                std::chrono::system_clock::time_point::max()};
+                                                std::chrono::steady_clock::time_point::max()};
 
 constexpr process_state_scheduled yield_immediate{process_state::yield,
-                                                  std::chrono::system_clock::time_point::min()};
+                                                  std::chrono::steady_clock::time_point::min()};
 
 /**************************************************************************************************/
 
@@ -838,9 +838,9 @@ struct shared_process
                 if (!dequeue()) break;
             }
 
-            auto now = std::chrono::system_clock::now();
+            auto now = std::chrono::steady_clock::now();
             process_state state;
-            std::chrono::system_clock::time_point when;
+            std::chrono::steady_clock::time_point when;
             std::tie(state, when) = get_process_state(_process);
 
             /*
@@ -866,7 +866,7 @@ struct shared_process
                 else if we await with an expired timeout then go ahead and yield now.
                 else schedule a timeout when we will yield if not canceled by intervening await.
             */
-            else if (when == std::chrono::system_clock::time_point::max()) {
+            else if (when == std::chrono::steady_clock::time_point::max()) {
                 task_done();
             } else if (when <= now) {
                 broadcast((*_process).yield());

--- a/stlab/concurrency/executor_base.hpp
+++ b/stlab/concurrency/executor_base.hpp
@@ -32,10 +32,10 @@ using executor_t = std::function<void(stlab::task<void()>)>;
  * at the given time point on the executor provided
  */
 
-inline executor_t execute_at(std::chrono::system_clock::time_point when, executor_t executor) {
+inline executor_t execute_at(std::chrono::steady_clock::time_point when, executor_t executor) {
     return [ _when = std::move(when), _executor = std::move(executor) ](auto f) mutable {
-        if ((_when != std::chrono::system_clock::time_point()) &&
-            (_when > std::chrono::system_clock::now()))
+        if ((_when != std::chrono::steady_clock::time_point()) &&
+            (_when > std::chrono::steady_clock::now()))
             system_timer(_when, [ _f = std::move(f), _executor = std::move(_executor) ]() mutable {
                 _executor(std::move(_f));
             });
@@ -50,8 +50,8 @@ inline executor_t execute_at(std::chrono::system_clock::time_point when, executo
  */
 
 template<typename E>
-auto execute_delayed(std::chrono::system_clock::duration duration, E executor) {
-    return execute_at(std::chrono::system_clock::now() + duration, std::move(executor));
+auto execute_delayed(std::chrono::steady_clock::duration duration, E executor) {
+    return execute_at(std::chrono::steady_clock::now() + duration, std::move(executor));
 }
 
 /**************************************************************************************************/

--- a/stlab/concurrency/immediate_executor.hpp
+++ b/stlab/concurrency/immediate_executor.hpp
@@ -33,7 +33,7 @@ struct immediate_executor_type
     }
 
     template <typename F>
-    void operator()(std::chrono::system_clock::time_point, F&& f) {
+    void operator()(std::chrono::steady_clock::time_point, F&& f) {
         std::forward<F>(f)();
     }
 };

--- a/stlab/concurrency/system_timer.hpp
+++ b/stlab/concurrency/system_timer.hpp
@@ -143,10 +143,17 @@ private:
         (*f)();
     }
 
+    time_t steady_clock_to_time_t(std::chrono::steady_clock::time_point t) const
+    {
+      return std::chrono::system_clock::to_time_t(std::chrono::system_clock::now() +
+        std::chrono::duration_cast<std::chrono::system_clock::duration>(t - std::chrono::steady_clock::now()));
+    }
+    
+
     FILETIME time_point_to_FILETIME(const std::chrono::steady_clock::time_point& when) const {
         FILETIME ft = { 0, 0 };
         SYSTEMTIME st = { 0 };
-        time_t t = std::chrono::steady_clock::to_time_t(when);
+        time_t t = steady_clock_to_time_t(when);
         tm utc_tm;
         if (!gmtime_s(&utc_tm, &t)) {
             st.wSecond = static_cast<WORD>(utc_tm.tm_sec);

--- a/test/channel_test_helper.hpp
+++ b/test/channel_test_helper.hpp
@@ -154,7 +154,7 @@ struct sum
 
 inline stlab::process_state_scheduled await_soon() {
     return std::make_pair(stlab::process_state::await,
-    std::chrono::system_clock::now() + std::chrono::seconds(1));
+    std::chrono::steady_clock::now() + std::chrono::seconds(1));
 }
 
 struct timed_sum

--- a/test/future_then_tests.cpp
+++ b/test/future_then_tests.cpp
@@ -382,7 +382,7 @@ BOOST_FIXTURE_TEST_SUITE(future_then_move_only, test_fixture<stlab::v1::move_onl
         
         stlab::v1::move_only m{ 42 };
         
-        sut = async(custom_scheduler<0>(), [&_m = m] () mutable {
+        sut = async(custom_scheduler<0>(), [] () mutable {
             return stlab::v1::move_only{ 10 };
         }).then([&_m = m] (auto x) mutable {
             return std::move(_m);
@@ -568,7 +568,7 @@ BOOST_FIXTURE_TEST_SUITE(future_void_then_error, test_fixture<void>)
         
         std::atomic_int p{ 0 };
 
-        auto sut = async(custom_scheduler<0>(), [&_p = p] { throw test_exception("failure"); })
+        auto sut = async(custom_scheduler<0>(), [] { throw test_exception("failure"); })
             .then([&_p = p] { _p = 42; });
 
         wait_until_future_fails<test_exception>(sut);

--- a/test/future_when_all_range_tests.cpp
+++ b/test/future_when_all_range_tests.cpp
@@ -341,7 +341,7 @@ BOOST_FIXTURE_TEST_SUITE(future_when_all_range_void_error, test_fixture<void>)
         auto start = async(custom_scheduler<0>(), []()->int { return 42; });
         std::vector<stlab::future<void>> futures(4);
         futures[0] = start.then(custom_scheduler<1>(), [&_p = v[0]](auto x) { _p = x + 1; });
-        futures[1] = start.then(custom_scheduler<1>(), [&_p = v[1]](auto x) { throw test_exception("failure"); });
+        futures[1] = start.then(custom_scheduler<1>(), []          (auto x) { throw test_exception("failure"); });
         futures[2] = start.then(custom_scheduler<1>(), [&_p = v[2]](auto x) { _p = x + 3; });
         futures[3] = start.then(custom_scheduler<1>(), [&_p = v[3]](auto x) { _p = x + 5; });
 
@@ -368,7 +368,7 @@ BOOST_FIXTURE_TEST_SUITE(future_when_all_range_void_error, test_fixture<void>)
         futures[2] = start.then(custom_scheduler<1>(), [&_p = v[2]](auto x) { _p = x + 3; });
         futures[3] = start.then(custom_scheduler<1>(), [&_p = v[3]](auto x) { _p = x + 5; });
 
-        sut = when_all(custom_scheduler<0>(), [&_r = r, &v]() { throw test_exception("failure"); }, 
+        sut = when_all(custom_scheduler<0>(), []() { throw test_exception("failure"); },
             std::make_pair(futures.begin(), futures.end()));
 
         wait_until_future_fails<test_exception>(sut);


### PR DESCRIPTION
Since the chrono::system_clock can be adjusted it is better to use instead the chrono::steady_clock.