### PR TITLE
Fix issue #94

### DIFF
--- a/stlab/concurrency/future.hpp
+++ b/stlab/concurrency/future.hpp
@@ -1343,7 +1343,7 @@ auto when_all(E executor, F f, const std::pair<I, I>& range) {
 
 
     if (range.first == range.second) {
-        auto p = package<result_t()>(std::move(executor),
+        auto p = package<result_t()>(executor,
                                      detail::context_result<F, false, context_result_t>(std::move(f), 0));
         executor(std::move(p.first));
         return std::move(p.second);


### PR DESCRIPTION
Fixing moved executor in when_all for ranges in case of an empty range