### PR TITLE
Fix for reduction of future<future<void>> in case of exception.

### DIFF
--- a/stlab/concurrency/future.hpp
+++ b/stlab/concurrency/future.hpp
@@ -327,7 +327,7 @@ struct shared_base<T, enable_if_copyable<T>> : std::enable_shared_from_this<shar
     template <typename R>
     auto reduce(R&& r) {
         return std::forward<R>(r);
-    };
+    }
 
     auto reduce(future<future<void>>&& r) -> future<void>;
 
@@ -448,7 +448,7 @@ struct shared_base<T, enable_if_not_copyable<T>> : std::enable_shared_from_this<
     template <typename R>
     auto reduce(R&& r) {
         return std::forward<R>(r);
-    };
+    }
 
     template <typename R>
     auto reduce(future<future<R>>&& r) -> future<R>;
@@ -537,7 +537,7 @@ struct shared_base<void> : std::enable_shared_from_this<shared_base<void>> {
     template <typename R>
     auto reduce(R&& r) {
         return std::forward<R>(r);
-    };
+    }
 
     auto reduce(future<future<void>>&& r) -> future<void>;
 


### PR DESCRIPTION
This fixes the issue I highlighted here:
https://github.com/stlab/libraries/issues/113

I've attempted to keep everything (code-style, tabs vs spaces) as close as possible to the surrounding code, and tried to keep the code related to future<future<void>> as close as possible to future<future<T>> to avoid future cases where voids behave differently than non-voids.

I wasn't sure whether to make a pull request to develop or to master. develop seemed the safer choice, and it should be relatively easy to cherrypick these commits to master.