### PR TITLE
Removing virtuals

### DIFF
--- a/stlab/concurrency/task.hpp
+++ b/stlab/concurrency/task.hpp
@@ -77,12 +77,13 @@ class task<R(Args...)> {
         const void* pointer() const noexcept { return _vtable_ptr->const_pointer(this); }
     };
 
-    struct empty;
     struct empty : concept {
         constexpr empty() noexcept : concept(&_vtable) {}
 
+        static void dtor(concept* self) { static_cast<empty*>(self)->~empty(); }
+
         constexpr static typename concept::vtable _vtable = {
-            [](concept* self) { static_cast<empty*>(self)->~empty(); },
+            dtor,
             [](concept*, void* p) noexcept { new (p) empty(); },
             [](concept*, Args&&...) -> R { throw std::bad_function_call(); },
             [](const concept*) noexcept->const std::type_info& { return typeid(void); },

--- a/stlab/concurrency/task.hpp
+++ b/stlab/concurrency/task.hpp
@@ -66,7 +66,7 @@ class task<R(Args...)> {
 
         const vtable* const _vtable_ptr;
 
-        concept(const vtable* p) : _vtable_ptr(p) {}
+        constexpr concept(const vtable* p) : _vtable_ptr(p) {}
         void dtor() { _vtable_ptr->dtor(this); }
         void move_ctor(void* p) noexcept { _vtable_ptr->move_ctor(this, p); }
         R invoke(Args&&... args) { return _vtable_ptr->invoke(this, std::forward<Args>(args)...); }

--- a/stlab/concurrency/task.hpp
+++ b/stlab/concurrency/task.hpp
@@ -225,7 +225,7 @@ public:
 
     void swap(task& x) noexcept { std::swap(*this, x); }
 
-    explicit operator bool() const { return self().pointer(); }
+    explicit operator bool() const { return static_cast<bool>(self().pointer()); }
 
     const std::type_info& target_type() const { return self().target_type(); }
 

--- a/stlab/concurrency/task.hpp
+++ b/stlab/concurrency/task.hpp
@@ -58,7 +58,7 @@ class task<R(Args...)> {
         return false;
     }
 
-    struct vtable_type {
+    struct concept {
         void (*dtor)(void*);
         void (*move_ctor)(void*, void*) noexcept;
         R (*invoke)(void*, Args&&...);
@@ -89,7 +89,7 @@ class task<R(Args...)> {
             return &static_cast<const model*>(self)->_f;
         }
 
-        static constexpr vtable_type _vtable = {dtor,        move_ctor, invoke,
+        static constexpr concept _vtable = {dtor,        move_ctor, invoke,
                                                 target_type, pointer,   const_pointer};
 
         F _f;
@@ -116,7 +116,7 @@ class task<R(Args...)> {
             return static_cast<const model*>(self)->_p.get();
         }
 
-        static constexpr vtable_type _vtable = {dtor,        move_ctor, invoke,
+        static constexpr concept _vtable = {dtor,        move_ctor, invoke,
                                                 target_type, pointer,   const_pointer};
 
         std::unique_ptr<F> _p;
@@ -130,10 +130,10 @@ class task<R(Args...)> {
     static auto pointer(void*) noexcept -> void* { return nullptr; }
     static auto const_pointer(const void*) noexcept -> const void* { return nullptr; }
 
-    static constexpr vtable_type _vtable = {dtor,        move_ctor, invoke,
+    static constexpr concept _vtable = {dtor,        move_ctor, invoke,
                                             target_type_, pointer,   const_pointer};
 
-    const vtable_type* _vtable_ptr = &_vtable;
+    const concept* _vtable_ptr = &_vtable;
 
     /*
         REVISIT (sean.parent) : The size of 256 was an arbitrary choice with no data to back it up.
@@ -222,13 +222,13 @@ public:
 #if (__cplusplus < 201703L)
 // In C++17 constexpr implies inline and these definitions are deprecated
 template <class R, class... Args>
-const typename task<R(Args...)>::vtable_type task<R(Args...)>::_vtable;
+const typename task<R(Args...)>::concept task<R(Args...)>::_vtable;
 template <class R, class... Args>
 template <class F>
-const typename task<R(Args...)>::vtable_type task<R(Args...)>::template model<F, false>::_vtable;
+const typename task<R(Args...)>::concept task<R(Args...)>::template model<F, false>::_vtable;
 template <class R, class... Args>
 template <class F>
-const typename task<R(Args...)>::vtable_type task<R(Args...)>::template model<F, true>::_vtable;
+const typename task<R(Args...)>::concept task<R(Args...)>::template model<F, true>::_vtable;
 #endif
 
 /**************************************************************************************************/

--- a/stlab/concurrency/task.hpp
+++ b/stlab/concurrency/task.hpp
@@ -225,7 +225,7 @@ public:
 
     void swap(task& x) noexcept { std::swap(*this, x); }
 
-    explicit operator bool() const { return static_cast<bool>(self().pointer()); }
+    explicit operator bool() const { return self().pointer() != nullptr; }
 
     const std::type_info& target_type() const { return self().target_type(); }
 

--- a/stlab/concurrency/task.hpp
+++ b/stlab/concurrency/task.hpp
@@ -77,6 +77,7 @@ class task<R(Args...)> {
         const void* pointer() const noexcept { return _vtable_ptr->const_pointer(this); }
     };
 
+    struct empty;
     struct empty : concept {
         constexpr empty() noexcept : concept(&_vtable) {}
 


### PR DESCRIPTION
Manually building vtables to avoid UB casting through void* with non-standard-layout classes (because inheritance with virtual members). concept and models should now be standard-layout.