### PR TITLE
comparison functions check for identity first

### DIFF
--- a/stlab/copy_on_write.hpp
+++ b/stlab/copy_on_write.hpp
@@ -134,7 +134,7 @@ public:
     }
 
     friend inline bool operator<(const copy_on_write& x, const copy_on_write& y) noexcept {
-        return *x < *y;
+        return !x.identity(y) && (*x < *y);
     }
 
     friend inline bool operator<(const copy_on_write& x, const element_type& y) noexcept {
@@ -182,7 +182,7 @@ public:
     }
 
     friend inline bool operator==(const copy_on_write& x, const copy_on_write& y) noexcept {
-        return *x == *y;
+        return x.identity(y) || (*x == *y);
     }
 
     friend inline bool operator==(const copy_on_write& x, const element_type& y) noexcept {


### PR DESCRIPTION
I implemented the performance optimisation I suggested as an issue, comparing a copy_on_write should check identity first.
Unittests did pass for me.
I did some performance tests, sorting a vector of 10 million items, using 100 different actual identities. For integers it got around 10% slower; for small strings (with SSO) it got 20% faster; for longer strings it got 40% faster.
I don't see much reason to use copy_on_write for a simple int; I assume that for every class one would reasonably wrap in a copy_on_write, this should be a performance increase.