### PR TITLE
Fix134 detach leak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
       before_install:
         - brew update
         - brew upgrade python
+        - brew uninstall libyaml
+        - pip3 install --no-cache-dir pyyaml
         - pip3 install conan
         - ./enhance_conan.sh
 
@@ -45,6 +47,8 @@ matrix:
       before_install:
         - brew update
         - brew upgrade python
+        - brew uninstall libyaml
+        - pip3 install --no-cache-dir pyyaml
         - pip3 install conan
         - ./enhance_conan.sh
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ ASL libraries will be migrated here in the stlab namespace, new libraries will b
 [![Master status](https://travis-ci.org/stlab/libraries.svg?branch=master)](https://travis-ci.org/stlab/libraries)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/aaf2uibkql1625dl/branch/master?svg=true)](https://ci.appveyor.com/project/fosterbrereton/libraries/branch/master)
 [![Code Coverage](https://codecov.io/github/stlab/libraries/coverage.svg?branch=master)](https://codecov.io/gh/stlab/libraries/branch/master)
+[![Coverty Scan](https://scan.coverity.com/projects/13163/badge.svg)](https://scan.coverity.com/projects/stlab_libraries)
+
 
 - **`develop`:**
 [![Travis status](https://travis-ci.org/stlab/libraries.svg?branch=develop)](https://travis-ci.org/stlab/libraries)


### PR DESCRIPTION
This fixes the leak in case of destructing a package_task, that has a detached continuation, without invoking it.
Currently, the Mac builds don't pass on Travis because of issue https://github.com/yaml/pyyaml/issues/152.