### PR TITLE
Fix problems building on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project( stlab LANGUAGES C CXX )
 
 option( coverage "Enable binary instrumentation to collect test coverage information in the DEBUG configuration" )
 option( stlab_testing "Compile the stlab tests and integrate with ctest" ${BUILD_TESTING} )
+option( stlab_force_boost_optional "Force use of Boost optional." OFF)
+option( stlab_force_boost_variant "Force use of Boost variant." OFF)
+option( stlab_disable_future_coroutines "Disable use of coroutines." OFF)
 
 set( Boost_MULTITHREADED ON ) 
 set( Boost_USE_STATIC_LIBS ON )
@@ -44,6 +47,19 @@ target_sources( stlab INTERFACE
                 "${CMAKE_CURRENT_SOURCE_DIR}/stlab/concurrency/tuple_algorithm.hpp"
                 "${CMAKE_CURRENT_SOURCE_DIR}/stlab/concurrency/utility.hpp"
                 "${CMAKE_CURRENT_SOURCE_DIR}/stlab/concurrency/variant.hpp")
+
+if( ${stlab_disable_future_coroutines} )
+  target_compile_definitions( stlab INTERFACE STLAB_DISABLE_FUTURE_COROUTINES )
+endif()
+
+if( ${Boost_FOUND} )
+  if( ${stlab_force_boost_optional} )
+    target_compile_definitions( stlab INTERFACE STLAB_FORCE_BOOST_OPTIONAL)
+  endif()
+  if( ${stlab_force_boost_variant} )
+    target_compile_definitions( stlab INTERFACE STLAB_FORCE_BOOST_VARIANT)
+  endif()
+endif()
 
 set( flags "${CMAKE_CURRENT_SOURCE_DIR}/cmake/${CMAKE_CXX_COMPILER_ID}.cmake" )
 if( EXISTS ${flags} )

--- a/stlab/concurrency/serial_queue.hpp
+++ b/stlab/concurrency/serial_queue.hpp
@@ -18,7 +18,9 @@
 
 #include <stlab/scope.hpp>
 
+#ifndef STLAB_DISABLE_FUTURE_COROUTINES
 #define STLAB_DISABLE_FUTURE_COROUTINES
+#endif
 
 #include <stlab/concurrency/future.hpp>
 #include <stlab/concurrency/task.hpp>

--- a/test/channel_functor_tests.cpp
+++ b/test/channel_functor_tests.cpp
@@ -8,7 +8,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#ifndef STLAB_DISABLE_FUTURE_COROUTINES
 #define STLAB_DISABLE_FUTURE_COROUTINES
+#endif
+
 #include <stlab/concurrency/channel.hpp>
 #include <stlab/concurrency/default_executor.hpp>
 #include <stlab/concurrency/future.hpp>

--- a/test/channel_merge_round_robin_tests.cpp
+++ b/test/channel_merge_round_robin_tests.cpp
@@ -8,7 +8,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#ifndef STLAB_DISABLE_FUTURE_COROUTINES
 #define STLAB_DISABLE_FUTURE_COROUTINES
+#endif
+
 #include <stlab/concurrency/channel.hpp>
 #include <stlab/concurrency/default_executor.hpp>
 #include <stlab/concurrency/future.hpp>

--- a/test/channel_merge_unordered_tests.cpp
+++ b/test/channel_merge_unordered_tests.cpp
@@ -8,7 +8,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#ifndef STLAB_DISABLE_FUTURE_COROUTINES
 #define STLAB_DISABLE_FUTURE_COROUTINES
+#endif
+
 #include <stlab/concurrency/channel.hpp>
 #include <stlab/concurrency/default_executor.hpp>
 #include <stlab/concurrency/future.hpp>

--- a/test/channel_merge_zip_with_tests.cpp
+++ b/test/channel_merge_zip_with_tests.cpp
@@ -8,7 +8,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#ifndef STLAB_DISABLE_FUTURE_COROUTINES
 #define STLAB_DISABLE_FUTURE_COROUTINES
+#endif
+
 #include <stlab/concurrency/channel.hpp>
 #include <stlab/concurrency/default_executor.hpp>
 #include <stlab/concurrency/future.hpp>

--- a/test/channel_process_tests.cpp
+++ b/test/channel_process_tests.cpp
@@ -8,7 +8,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+#ifndef STLAB_DISABLE_FUTURE_COROUTINES
 #define STLAB_DISABLE_FUTURE_COROUTINES
+#endif
 
 #include <stlab/concurrency/channel.hpp>
 #include <stlab/concurrency/default_executor.hpp>

--- a/test/channel_test_helper.hpp
+++ b/test/channel_test_helper.hpp
@@ -9,7 +9,10 @@
 #ifndef CHANNEL_TEST_HELPER_
 #define CHANNEL_TEST_HELPER_
 
+#ifndef STLAB_DISABLE_FUTURE_COROUTINES
 #define STLAB_DISABLE_FUTURE_COROUTINES
+#endif
+
 #include <stlab/concurrency/channel.hpp>
 #include <stlab/concurrency/default_executor.hpp>
 #include <stlab/concurrency/task.hpp>

--- a/test/channel_tests.cpp
+++ b/test/channel_tests.cpp
@@ -8,7 +8,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#ifndef STLAB_DISABLE_FUTURE_COROUTINES
 #define STLAB_DISABLE_FUTURE_COROUTINES
+#endif
+
 #include <stlab/concurrency/channel.hpp>
 #include <stlab/concurrency/default_executor.hpp>
 #include <stlab/concurrency/future.hpp>

--- a/test/future_when_any_range_tests.cpp
+++ b/test/future_when_any_range_tests.cpp
@@ -605,7 +605,7 @@ BOOST_AUTO_TEST_CASE(future_when_any_move_only_range_with_diamond_formation_elem
     sut = when_any(custom_scheduler<1>(),
       [&_i = index](stlab::move_only x, size_t index) {
       _i = index;
-      return std::move(x);
+      return x;
     },
       std::make_pair(futures.begin(), futures.end()));
 

--- a/test/tuple_test.cpp
+++ b/test/tuple_test.cpp
@@ -13,7 +13,10 @@
 #include <boost/test/unit_test.hpp>
 
 // stlab
+#ifndef STLAB_DISABLE_FUTURE_COROUTINES
 #define STLAB_DISABLE_FUTURE_COROUTINES
+#endif
+
 #include <stlab/concurrency/default_executor.hpp>
 #include <stlab/concurrency/future.hpp>
 #include <stlab/concurrency/tuple_algorithm.hpp>


### PR DESCRIPTION
In order to build successfully on macOS using CMake, I needed options to force the use of boost::optional and boost::variant since these header files exist but are either incomplete or commented out. And I also needed to disable coroutines. To that end, I've added cmake options following the pattern for building tests.

Meanwhile, I needed to now protect from redefinition of the macro STLAB_DISABLE_FUTURE_COROUTINES.

And incidentally found a redundant std::move call on return in test/future_when_any_range_tests.cpp that the compiler flagged and so I fixed it.