### PR TITLE
Lock the condition

### DIFF
--- a/stlab/concurrency/utility.hpp
+++ b/stlab/concurrency/utility.hpp
@@ -130,8 +130,8 @@ stlab::optional<T> blocking_get(future<T> x, const std::chrono::nanoseconds& tim
             {
                 std::unique_lock<std::mutex> lock{state->m};
                 state->flag = true;
+                state->condition.notify_one();
             }
-            state->condition.notify_one();
         });
 
     {
@@ -185,8 +185,8 @@ inline bool blocking_get(future<void> x, const std::chrono::nanoseconds& timeout
             {
                 std::unique_lock<std::mutex> lock(state->m);
                 state->flag = true;
+                state->condition.notify_one();
             }
-            state->condition.notify_one();
         });
 
     {


### PR DESCRIPTION
- Updated varients of `blocking_get()` to properly
  `notify_one()` under lock. This brings them into
  alignment with the other versions of `blocking_get()`