### PR TITLE
[cmake] Fix: Loose ends from PR #180

### DIFF
--- a/cmake/stlabConfig.cmake
+++ b/cmake/stlabConfig.cmake
@@ -1,4 +1,3 @@
 include( CMakeFindDependencyMacro )
-find_dependency( Boost 1.60.0 REQUIRED COMPONENTS unit_test_framework )
 find_package(Threads REQUIRED)
 include( "${CMAKE_CURRENT_LIST_DIR}/stlabTargets.cmake" )

--- a/cmake/stlabConfig.cmake
+++ b/cmake/stlabConfig.cmake
@@ -1,3 +1,4 @@
 include( CMakeFindDependencyMacro )
-find_package(Threads REQUIRED)
+find_dependency(Boost 1.60.0)
+find_dependency(Threads)
 include( "${CMAKE_CURRENT_LIST_DIR}/stlabTargets.cmake" )

--- a/cmake/stlabConfig.cmake
+++ b/cmake/stlabConfig.cmake
@@ -1,3 +1,4 @@
 include( CMakeFindDependencyMacro )
 find_dependency( Boost 1.60.0 REQUIRED COMPONENTS unit_test_framework )
+find_package(Threads REQUIRED)
 include( "${CMAKE_CURRENT_LIST_DIR}/stlabTargets.cmake" )

--- a/stlab/concurrency/CMakeLists.txt
+++ b/stlab/concurrency/CMakeLists.txt
@@ -1,14 +1,5 @@
-string( CONCAT conditional_exclusion
-  "$<NOT:$<AND:$<CXX_COMPILER_ID:MSVC>"
-             ",$<VERSION_LESS:$<CXX_COMPILER_VERSION>,99>"
-             ",$<BOOL:$<TARGET_PROPERTY:COROUTINES>"
-               ">"
-         ">"
-   ">" )
-
 target_sources( stlab INTERFACE
   $<BUILD_INTERFACE:
-    $<${conditional_exclusion}:${CMAKE_CURRENT_SOURCE_DIR}/channel.hpp>
     ${CMAKE_CURRENT_SOURCE_DIR}/config.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/default_executor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/executor_base.hpp
@@ -24,7 +15,6 @@ target_sources( stlab INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/utility.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/variant.hpp>
   $<INSTALL_INTERFACE:
-    $<${conditional_exclusion}:include/stlab/concurrency/channel.hpp>
     include/stlab/concurrency/channel.hpp
     include/stlab/concurrency/config.hpp
     include/stlab/concurrency/default_executor.hpp
@@ -39,4 +29,18 @@ target_sources( stlab INTERFACE
     include/stlab/concurrency/traits.hpp
     include/stlab/concurrency/tuple_algorithm.hpp
     include/stlab/concurrency/utility.hpp
-    include/stlab/concurrency/variant.hpp> )
+    include/stlab/concurrency/variant.hpp>)
+
+if(CXX_COMPILER_ID MATCHES MSVC)
+  if(CXX_COMPILER_VERSION VERSION_LESS 99)
+    get_target_property(wants_coroutines stlab COROUTINES)
+    if(wants_coroutines)
+      message(STATUS "Not including concurrency/channel.hpp in the target sources for stlab")
+      return()
+    endif()
+  endif()
+endif()
+
+target_sources(stlab INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/channel.hpp>
+  $<INSTALL_INTERFACE:include/stlab/concurrency/channel.hpp>)


### PR DESCRIPTION
With this change, I get

```
~/d/S/build cmake ..
-- The CXX compiler identification is AppleClang 9.1.0.9020039
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for C++ include pthread.h
-- Looking for C++ include pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Threads: TRUE
-- Configuring done
CMake Error at CMakeLists.txt:5 (add_executable):
  Cannot find source file:

    include/stlab/concurrency/channel.hpp

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm
  .hpp .hxx .in .txx


-- Generating done
-- Build files have been written to: /Users/raoulwols/dev/StlabCheck/build
```

with this cmakelists:

```cmake
cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
project(StlabCheck VERSION 0.1.0 LANGUAGES CXX)
find_package(stlab REQUIRED CONFIG)
add_executable(foo main.cpp)
target_link_libraries(foo PRIVATE stlab::stlab)
```
So this is one piece of the puzzle.