### PR TITLE
Check for ARC

### DIFF
--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -63,7 +63,9 @@ private:
         dispatch_group_t _group = dispatch_group_create();
         ~group() {
             dispatch_group_wait(_group, DISPATCH_TIME_FOREVER);
+#if !__has_feature(objc_arc)
             dispatch_release(_group);
+#endif
         }
     };
 


### PR DESCRIPTION
- If ARC is enabled in Xcode then `dispatch_release()`
  will not compile since it is no longer needed.