### PR TITLE
fix tasks execution for schedule_mode::all

### DIFF
--- a/stlab/concurrency/serial_queue.hpp
+++ b/stlab/concurrency/serial_queue.hpp
@@ -79,7 +79,8 @@ class serial_instance_t : public std::enable_shared_from_this<serial_instance_t>
         scope<lock_t>(_m, [&]() { std::swap(local_queue, _queue); });
 
         while (!local_queue.empty()) {
-            pop_front_unsafe(local_queue)();
+            auto f = pop_front_unsafe(local_queue)();
+            f();
         }
 
         if (!empty()) _executor([_this(shared_from_this())]() { _this->all(); });


### PR DESCRIPTION
If I am not mistaken, tasks are destroyed but never executed when the 'all' routine is called.