### PR TITLE
Fix192

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,7 @@ matrix:
         TSAN_OPTIONS="suppressions=${TRAVIS_BUILD_DIR}/test/sanitizer_suppressions"
         flags="-fsanitize=thread -fno-omit-frame-pointer -fno-sanitize-recover=all"
         options=""
+      sudo: true
 
     #
     # Coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,6 @@ matrix:
         TSAN_OPTIONS="suppressions=${TRAVIS_BUILD_DIR}/test/sanitizer_suppressions"
         flags="-fsanitize=thread -fno-omit-frame-pointer -fno-sanitize-recover=all"
         options=""
-      sudo: true
 
     #
     # Coverage

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## v1.3.3 - 2018 - October - 25
+
+- Fixed Issues 
+   - [#154](https://github.com/stlab/libraries/issues/154) : 
+   - Race condition in blockin_get(future<T>, const std::chrono::nanoseconds&)
+   
+- Enhancedments
+   - The library can now be included as cmake dependency (Many thanks to Austin McCartney)  
+    
 ## v1.3.2 - 2018 - July - 28
 
 - Fixed Issues 

--- a/cmake/stlab/development/Clang.cmake
+++ b/cmake/stlab/development/Clang.cmake
@@ -1,4 +1,4 @@
-set( stlab_Clang_base_flags -Wall -Wextra -Wpedantic -Werror -ftemplate-backtrace-limit=0 )
+set( stlab_Clang_base_flags -Wall -Wextra -Wpedantic -Werror -ftemplate-backtrace-limit=0 -DBOOST_NO_AUTO_PTR=1)
 set( stlab_Clang_debug_flags -gdwarf-3 )
 set( stlab_Clang_coverage_flags --coverage )
 set( stlab_Clang_release_flags )

--- a/stlab/concurrency/future.hpp
+++ b/stlab/concurrency/future.hpp
@@ -1732,7 +1732,7 @@ auto shared_base<void>::reduce(future<future<R>>&& r) -> future<R> {
 
 /**************************************************************************************************/
 
-#if STLAB_FUTURE_COROUTINES_SUPPORT
+#ifdef STLAB_FUTURE_COROUTINES_SUPPORT
 
 template <typename T, typename... Args>
 struct std::experimental::coroutine_traits<stlab::future<T>, Args...> {

--- a/stlab/concurrency/future.hpp
+++ b/stlab/concurrency/future.hpp
@@ -218,7 +218,7 @@ struct value_setter;
 /**************************************************************************************************/
 
 template <typename Sig, typename E, typename F>
-auto package(E&&, F &&)
+auto package(E, F&&)
     -> std::pair<detail::packaged_task_from_signature_t<Sig>, future<detail::result_of_t_<Sig>>>;
 
 /**************************************************************************************************/
@@ -664,11 +664,11 @@ class packaged_task {
     explicit packaged_task(ptr_t p) : _p(std::move(p)) {}
 
     template <typename Signature, typename E, typename F>
-    friend auto package(E&&, F &&) -> std::pair<detail::packaged_task_from_signature_t<Signature>,
-                                                future<detail::result_of_t_<Signature>>>;
+    friend auto package(E, F&&) -> std::pair<detail::packaged_task_from_signature_t<Signature>,
+                                              future<detail::result_of_t_<Signature>>>;
 
     template <typename Signature, typename E, typename F>
-    friend auto package_with_broken_promise(E&&, F&&)
+    friend auto package_with_broken_promise(E, F&&)
         -> std::pair<detail::packaged_task_from_signature_t<Signature>,
                      future<detail::result_of_t_<Signature>>>;
 
@@ -715,11 +715,11 @@ class future<T, enable_if_copyable<T>> {
     explicit future(ptr_t p) : _p(std::move(p)) {}
 
     template <typename Signature, typename E, typename F>
-    friend auto package(E&&, F&&) -> std::pair<detail::packaged_task_from_signature_t<Signature>,
-                                                future<detail::result_of_t_<Signature>>>;
+    friend auto package(E, F&&) -> std::pair<detail::packaged_task_from_signature_t<Signature>,
+                                             future<detail::result_of_t_<Signature>>>;
 
     template <typename Signature, typename E, typename F>
-    friend auto package_with_broken_promise(E&&, F &&)
+    friend auto package_with_broken_promise(E, F &&)
         -> std::pair<detail::packaged_task_from_signature_t<Signature>,
                      future<detail::result_of_t_<Signature>>>;
 
@@ -806,11 +806,11 @@ class future<void, void> {
     explicit future(ptr_t p) : _p(std::move(p)) {}
 
     template <typename Signature, typename E, typename F>
-    friend auto package(E&&, F &&) -> std::pair<detail::packaged_task_from_signature_t<Signature>,
-                                                future<detail::result_of_t_<Signature>>>;
+    friend auto package(E, F&&) -> std::pair<detail::packaged_task_from_signature_t<Signature>,
+                                              future<detail::result_of_t_<Signature>>>;
 
     template <typename Signature, typename E, typename F>
-    friend auto package_with_broken_promise(E&&, F &&)
+    friend auto package_with_broken_promise(E, F &&)
         -> std::pair<detail::packaged_task_from_signature_t<Signature>,
                      future<detail::result_of_t_<Signature>>>;
 
@@ -896,11 +896,11 @@ class future<T, enable_if_not_copyable<T>> {
     future(const future&) = default;
 
     template <typename Signature, typename E, typename F>
-    friend auto package(E&&, F &&) -> std::pair<detail::packaged_task_from_signature_t<Signature>,
-                                           future<detail::result_of_t_<Signature>>>;
+    friend auto package(E, F &&) -> std::pair<detail::packaged_task_from_signature_t<Signature>,
+                                              future<detail::result_of_t_<Signature>>>;
 
     template <typename Signature, typename E, typename F>
-    friend auto package_with_broken_promise(E&&, F &&)
+    friend auto package_with_broken_promise(E, F &&)
         -> std::pair<detail::packaged_task_from_signature_t<Signature>,
                      future<detail::result_of_t_<Signature>>>;
 
@@ -961,17 +961,17 @@ public:
 };
 
 template <typename Sig, typename E, typename F>
-auto package(E&& executor, F&& f)
+auto package(E executor, F&& f)
     -> std::pair<detail::packaged_task_from_signature_t<Sig>, future<detail::result_of_t_<Sig>>> {
-    auto p = std::make_shared<detail::shared<Sig>>(std::forward<E>(executor), std::forward<F>(f));
+    auto p = std::make_shared<detail::shared<Sig>>(std::move(executor), std::forward<F>(f));
     return std::make_pair(detail::packaged_task_from_signature_t<Sig>(p),
                           future<detail::result_of_t_<Sig>>(p));
 }
 
 template <typename Sig, typename E, typename F>
-auto package_with_broken_promise(E&& executor, F&& f)
+auto package_with_broken_promise(E executor, F&& f)
     -> std::pair<detail::packaged_task_from_signature_t<Sig>, future<detail::result_of_t_<Sig>>> {
-    auto p = std::make_shared<detail::shared<Sig>>(std::forward<E>(executor), std::forward<F>(f));
+    auto p = std::make_shared<detail::shared<Sig>>(std::move(executor), std::forward<F>(f));
     auto result = std::make_pair(detail::packaged_task_from_signature_t<Sig>(p),
                                  future<detail::result_of_t_<Sig>>(p));
     result.second._p->_error =

--- a/stlab/concurrency/future.hpp
+++ b/stlab/concurrency/future.hpp
@@ -1165,7 +1165,7 @@ auto when_all(E executor, F f, future<Ts>... args) {
     });
     shared->_f = std::move(p.first);
 
-    detail::attach_when_args(std::move(executor), shared, std::move(args)...);
+    detail::attach_when_args(executor, shared, std::move(args)...);
 
     return std::move(p.second);
 }
@@ -1184,7 +1184,7 @@ struct make_when_any {
         });
         shared->_f = std::move(p.first);
 
-        detail::attach_when_args(std::move(executor), shared, std::move(arg), std::move(args)...);
+        detail::attach_when_args(executor, shared, std::move(arg), std::move(args)...);
 
         return std::move(p.second);
     }
@@ -1204,7 +1204,7 @@ struct make_when_any<void> {
         });
         shared->_f = std::move(p.first);
 
-        detail::attach_when_args(std::move(executor), shared, std::move(args)...);
+        detail::attach_when_args(executor, shared, std::move(args)...);
 
         return std::move(p.second);
     }

--- a/stlab/concurrency/future.hpp
+++ b/stlab/concurrency/future.hpp
@@ -1392,9 +1392,9 @@ struct common_context : CR {
 /**************************************************************************************************/
 
 template <typename C, typename E, typename T>
-void attach_tasks(size_t index, E&& executor, const std::shared_ptr<C>& context, T&& a) {
+void attach_tasks(size_t index, E executor, const std::shared_ptr<C>& context, T&& a) {
     context->_holds[index] =
-        std::move(a).recover(std::forward<E>(executor), [_context = std::weak_ptr<C>(context), _i = index](auto x) {
+        std::move(a).recover(std::move(executor), [_context = std::weak_ptr<C>(context), _i = index](auto x) {
             auto p = _context.lock();
             if (!p) return;
             auto error = x.error();
@@ -1477,7 +1477,7 @@ auto when_all(E executor, F f, std::pair<I, I> range) {
     }
 
     return detail::create_range_of_futures<result_t, param_t, context_t>::do_it(
-        std::move(executor), std::move(f), range.first, range.second);
+        executor, std::move(f), range.first, range.second);
 }
 
 /**************************************************************************************************/

--- a/test/future_recover_tests.cpp
+++ b/test/future_recover_tests.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(future_recover_failure_before_recover_initialized_on_rvalue
 
     auto error = false;
 
-    sut = async(custom_scheduler<0>(),
+    sut = async(make_executor<0>(),
                 [& _error = error] {
                     _error = true;
                     throw test_exception("failure");
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(future_recover_failure_before_recover_initialized_on_lvalue
     BOOST_TEST_MESSAGE("running future recover, failure before recover initialized on l-value");
 
     auto error = false;
-    auto interim = async(custom_scheduler<0>(), [& _error = error] {
+    auto interim = async(make_executor<0>(), [& _error = error] {
         _error = true;
         throw test_exception("failure");
     });
@@ -66,12 +66,12 @@ BOOST_AUTO_TEST_CASE(
 
     auto error = false;
 
-    sut = async(custom_scheduler<0>(),
+    sut = async(make_executor<0>(),
                 [& _error = error] {
                     _error = true;
                     throw test_exception("failure");
                 })
-              .recover(custom_scheduler<1>(), [](auto failedFuture) {
+              .recover(make_executor<1>(), [](auto failedFuture) {
                   check_failure<test_exception>(failedFuture, "failure");
               });
 
@@ -88,14 +88,14 @@ BOOST_AUTO_TEST_CASE(
         "running future recover, failure before recover initialized, with custom scheduler on l-value");
 
     auto error = false;
-    auto interim = async(custom_scheduler<0>(), [& _error = error] {
+    auto interim = async(make_executor<0>(), [& _error = error] {
         _error = true;
         throw test_exception("failure");
     });
 
     wait_until_future_fails<test_exception>(interim);
 
-    sut = interim.recover(custom_scheduler<1>(), [](auto failedFuture) {
+    sut = interim.recover(make_executor<1>(), [](auto failedFuture) {
         check_failure<test_exception>(failedFuture, "failure");
     });
 
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(future_recover_failure_after_recover_initialized_on_rvalue)
 
     {
         lock_t hold(block);
-        sut = async(custom_scheduler<0>(),
+        sut = async(make_executor<0>(),
                     [& _error = error, &_block = block] {
                         lock_t lock(_block);
                         _error = true;
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(future_recover_failure_after_recover_initialized_on_lvalue)
 
     {
         lock_t hold(block);
-        auto interim = async(custom_scheduler<0>(), [& _error = error, &_block = block] {
+        auto interim = async(make_executor<0>(), [& _error = error, &_block = block] {
             lock_t lock(_block);
             _error = true;
             throw test_exception("failure");
@@ -165,13 +165,13 @@ BOOST_AUTO_TEST_CASE(
 
     {
         lock_t hold(block);
-        sut = async(custom_scheduler<0>(),
+        sut = async(make_executor<0>(),
                     [& _error = error, &_block = block] {
                         lock_t lock(_block);
                         _error = true;
                         throw test_exception("failure");
                     })
-                  .recover(custom_scheduler<1>(), [](auto failedFuture) {
+                  .recover(make_executor<1>(), [](auto failedFuture) {
                       check_failure<test_exception>(failedFuture, "failure");
                   });
     }
@@ -193,13 +193,13 @@ BOOST_AUTO_TEST_CASE(
 
     {
         lock_t hold(block);
-        auto interim = async(custom_scheduler<0>(), [& _error = error, &_block = block] {
+        auto interim = async(make_executor<0>(), [& _error = error, &_block = block] {
             lock_t lock(_block);
             _error = true;
             throw test_exception("failure");
         });
 
-        sut = interim.recover(custom_scheduler<1>(), [](auto failedFuture) {
+        sut = interim.recover(make_executor<1>(), [](auto failedFuture) {
             check_failure<test_exception>(failedFuture, "failure");
         });
     }
@@ -215,10 +215,10 @@ BOOST_AUTO_TEST_CASE(future_recover_failure_during_when_all_on_lvalue) {
     BOOST_TEST_MESSAGE("running future recover while failed when_all on l-value");
 
     int result{0};
-    auto f1 = async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); });
-    auto f2 = async(custom_scheduler<1>(), [] { return 42; });
+    auto f1 = async(make_executor<0>(), []() -> int { throw test_exception("failure"); });
+    auto f2 = async(make_executor<1>(), [] { return 42; });
 
-    sut = when_all(custom_scheduler<0>(), [](int x, int y) { return x + y; }, f1, f2)
+    sut = when_all(make_executor<0>(), [](int x, int y) { return x + y; }, f1, f2)
               .recover([](auto error) {
                   if (error.error())
                       return 815;
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(
 
     auto error = false;
 
-    sut = async(custom_scheduler<0>(),
+    sut = async(make_executor<0>(),
                 [& _error = error]() -> int {
                     _error = true;
                     throw test_exception("failure");
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(
     BOOST_TEST_MESSAGE("running future int recover, failure before recover initialized on l-value");
 
     auto error = false;
-    auto interim = async(custom_scheduler<0>(), [& _error = error]() -> int {
+    auto interim = async(make_executor<0>(), [& _error = error]() -> int {
         _error = true;
         throw test_exception("failure");
     });
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(
     {
         lock_t hold(block);
 
-        sut = async(custom_scheduler<0>(),
+        sut = async(make_executor<0>(),
                     [& _error = error, &_block = block]() -> int {
                         lock_t lock(_block);
                         _error = true;
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE(
     {
         lock_t hold(block);
 
-        auto interim = async(custom_scheduler<0>(), [& _error = error, &_block = block]() -> int {
+        auto interim = async(make_executor<0>(), [& _error = error, &_block = block]() -> int {
             lock_t lock(_block);
             _error = true;
             throw test_exception("failure");
@@ -339,12 +339,12 @@ BOOST_AUTO_TEST_CASE(
 
     auto error = false;
 
-    sut = async(custom_scheduler<0>(),
+    sut = async(make_executor<0>(),
                 [& _error = error]() -> int {
                     _error = true;
                     throw test_exception("failure");
                 })
-              .recover(custom_scheduler<1>(), [](auto failedFuture) {
+              .recover(make_executor<1>(), [](auto failedFuture) {
                   check_failure<test_exception>(failedFuture, "failure");
                   return 42;
               });
@@ -363,14 +363,14 @@ BOOST_AUTO_TEST_CASE(
         "running future int recover, failure before recover initialized with custom scheduler on l-value");
 
     auto error = false;
-    auto interim = async(custom_scheduler<0>(), [& _error = error]() -> int {
+    auto interim = async(make_executor<0>(), [& _error = error]() -> int {
         _error = true;
         throw test_exception("failure");
     });
 
     wait_until_future_fails<test_exception>(interim);
 
-    sut = interim.recover(custom_scheduler<1>(), [](auto failedFuture) {
+    sut = interim.recover(make_executor<1>(), [](auto failedFuture) {
         check_failure<test_exception>(failedFuture, "failure");
         return 42;
     });
@@ -394,13 +394,13 @@ BOOST_AUTO_TEST_CASE(
     {
         lock_t hold(block);
 
-        sut = async(custom_scheduler<0>(),
+        sut = async(make_executor<0>(),
                     [& _error = error, &_block = block]() -> int {
                         lock_t lock(_block);
                         _error = true;
                         throw test_exception("failure");
                     })
-                  .recover(custom_scheduler<1>(), [](auto failedFuture) {
+                  .recover(make_executor<1>(), [](auto failedFuture) {
                       check_failure<test_exception>(failedFuture, "failure");
                       return 42;
                   });
@@ -424,13 +424,13 @@ BOOST_AUTO_TEST_CASE(
 
     {
         lock_t hold(block);
-        auto interim = async(custom_scheduler<0>(), [& _error = error, &_block = block]() -> int {
+        auto interim = async(make_executor<0>(), [& _error = error, &_block = block]() -> int {
             lock_t lock(_block);
             _error = true;
             throw test_exception("failure");
         });
 
-        sut = interim.recover(custom_scheduler<1>(), [](auto failedFuture) {
+        sut = interim.recover(make_executor<1>(), [](auto failedFuture) {
             check_failure<test_exception>(failedFuture, "failure");
             return 42;
         });
@@ -454,7 +454,7 @@ BOOST_AUTO_TEST_CASE(
 
     auto error = false;
 
-    sut = async(custom_scheduler<0>(),
+    sut = async(make_executor<0>(),
                 [& _error = error]() -> move_only {
                     _error = true;
                     throw test_exception("failure");
@@ -478,7 +478,7 @@ BOOST_AUTO_TEST_CASE(future_recover_move_only_types_recover_failure_after_recove
     {
         lock_t hold(block);
 
-        sut = async(custom_scheduler<0>(),
+        sut = async(make_executor<0>(),
                     [& _error = error, &_block = block]() -> move_only {
                         lock_t lock(_block);
                         _error = true;
@@ -503,12 +503,12 @@ BOOST_AUTO_TEST_CASE(
 
     auto error = false;
 
-    sut = async(custom_scheduler<0>(),
+    sut = async(make_executor<0>(),
                 [& _error = error]() -> move_only {
                     _error = true;
                     throw test_exception("failure");
                 })
-              .recover(custom_scheduler<1>(), [](auto failedFuture) {
+              .recover(make_executor<1>(), [](auto failedFuture) {
                   check_failure<test_exception>(failedFuture, "failure");
                   return move_only(42);
               });
@@ -530,13 +530,13 @@ BOOST_AUTO_TEST_CASE(
     std::mutex block;
     {
         lock_t hold(block);
-        sut = async(custom_scheduler<0>(),
+        sut = async(make_executor<0>(),
                     [& _error = error, &_block = block]() -> move_only {
                         lock_t lock(_block);
                         _error = true;
                         throw test_exception("failure");
                     })
-                  .recover(custom_scheduler<1>(), [](auto failedFuture) {
+                  .recover(make_executor<1>(), [](auto failedFuture) {
                       check_failure<test_exception>(failedFuture, "failure");
                       return move_only(42);
                   });

--- a/test/future_test_helper.cpp
+++ b/test/future_test_helper.cpp
@@ -18,5 +18,3 @@ const char* test_exception::what() const noexcept { return _error.c_str(); }
 
 } // namespace future_test_helper
 
-std::vector<std::string> payloadHolder;
-std::mutex payloadHolderMutex;

--- a/test/future_test_helper.cpp
+++ b/test/future_test_helper.cpp
@@ -19,3 +19,4 @@ const char* test_exception::what() const noexcept { return _error.c_str(); }
 } // namespace future_test_helper
 
 std::vector<std::string> payloadHolder;
+std::mutex payloadHolderMutex;

--- a/test/future_test_helper.cpp
+++ b/test/future_test_helper.cpp
@@ -17,3 +17,5 @@ test_exception::test_exception(const char* error) : _error(error) {}
 const char* test_exception::what() const noexcept { return _error.c_str(); }
 
 } // namespace future_test_helper
+
+std::vector<std::string> payloadHolder;

--- a/test/future_test_helper.hpp
+++ b/test/future_test_helper.hpp
@@ -19,10 +19,9 @@
 #include <thread>
 
 using lock_t = std::unique_lock<std::mutex>;
-extern std::mutex payloadHolderMutex;
-extern std::vector<std::string> payloadHolder;
 
 namespace future_test_helper {
+
 template <std::size_t no>
 struct custom_scheduler {
     using result_type = void;
@@ -31,11 +30,6 @@ struct custom_scheduler {
         ++counter();
         // The implementation on Windows or the mac uses a scheduler that allows many tasks in the
         // pool in parallel
-        {
-            lock_t lock(payloadHolderMutex);
-            payloadHolder.push_back(_payload);
-        }
-
 #if defined(WIN32) || defined(__APPLE__)
         stlab::default_executor(std::move(f));
 #else
@@ -49,10 +43,6 @@ struct custom_scheduler {
 
     static void reset() {
         counter() = 0;
-        {
-            lock_t lock(payloadHolderMutex);
-            payloadHolder.resize(0);
-        }
     }
 
     static std::atomic_int& counter() {
@@ -61,7 +51,6 @@ struct custom_scheduler {
     }
 
 private:
-    std::string _payload = "DummyPayload";
     size_t _id = no; // only used for debugging purpose
 };
 

--- a/test/future_tests.cpp
+++ b/test/future_tests.cpp
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(future_constructed_minimal_fn, T, copyable_test_ty
 
     test_setup setup;
     {
-        auto sut = async(custom_scheduler<0>(), []() -> T { return T(0); });
+        auto sut = async(make_executor<0>(), []() -> T { return T(0); });
         BOOST_REQUIRE(sut.valid() == true);
         BOOST_REQUIRE(!sut.error());
 
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(future_constructed_minimal_fn_with_parameters,
 
     test_setup setup;
     {
-        auto sut = async(custom_scheduler<0>(), [](auto x) -> T { return x + T(0); }, T(42));
+        auto sut = async(make_executor<0>(), [](auto x) -> T { return x + T(0); }, T(42));
         BOOST_REQUIRE(sut.valid() == true);
         BOOST_REQUIRE(!sut.error());
 
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE(future_constructed_minimal_fn_moveonly) {
     test_setup setup;
     {
         auto sut =
-            async(custom_scheduler<0>(), []() -> v1::move_only { return v1::move_only{42}; });
+            async(make_executor<0>(), []() -> v1::move_only { return v1::move_only{42}; });
         BOOST_REQUIRE(sut.valid() == true);
         BOOST_REQUIRE(!sut.error());
 

--- a/test/future_when_all_arguments_tests.cpp
+++ b/test/future_when_all_arguments_tests.cpp
@@ -23,8 +23,8 @@ BOOST_FIXTURE_TEST_SUITE(future_when_all_args_int, test_fixture<int>)
 BOOST_AUTO_TEST_CASE(future_when_all_args_int_with_one_element) {
     BOOST_TEST_MESSAGE("running future when_all int with one element");
 
-    auto f1 = async(custom_scheduler<0>(), [] { return 42; });
-    sut = when_all(custom_scheduler<1>(), [](auto x) { return x + x; }, f1);
+    auto f1 = async(make_executor<0>(), [] { return 42; });
+    sut = when_all(make_executor<1>(), [](auto x) { return x + x; }, f1);
 
     check_valid_future(sut);
     wait_until_future_completed(sut);
@@ -37,13 +37,13 @@ BOOST_AUTO_TEST_CASE(future_when_all_args_int_with_one_element) {
 BOOST_AUTO_TEST_CASE(future_when_all_args_int_with_many_elements) {
     BOOST_TEST_MESSAGE("running future when_all args int with many elements");
 
-    auto f1 = async(custom_scheduler<0>(), [] { return 1; });
-    auto f2 = async(custom_scheduler<0>(), [] { return 2; });
-    auto f3 = async(custom_scheduler<0>(), [] { return 3; });
-    auto f4 = async(custom_scheduler<0>(), [] { return 5; });
+    auto f1 = async(make_executor<0>(), [] { return 1; });
+    auto f2 = async(make_executor<0>(), [] { return 2; });
+    auto f3 = async(make_executor<0>(), [] { return 3; });
+    auto f4 = async(make_executor<0>(), [] { return 5; });
 
     sut = when_all(
-        custom_scheduler<1>(),
+        make_executor<1>(),
         [](int x1, int x2, int x3, int x4) { return 7 * x1 + 11 * x2 + 13 * x3 + 17 * x4; }, f1, f2,
         f3, f4);
 
@@ -58,7 +58,22 @@ BOOST_AUTO_TEST_CASE(future_when_all_args_int_with_many_elements) {
 BOOST_AUTO_TEST_CASE(future_when_all_args_int_with_ready_element) {
     BOOST_TEST_MESSAGE("running future when_all int with ready element");
 
-    sut = when_all(custom_scheduler<1>(), [](auto x) { return x + x; }, make_ready_future<int>(42, immediate_executor));
+    sut = when_all(make_executor<1>(), [](auto x) { return x + x; },
+        make_ready_future<int>(42, immediate_executor));
+
+    check_valid_future(sut);
+    wait_until_future_completed(sut);
+
+    BOOST_REQUIRE_EQUAL(42 + 42, *sut.get_try());
+    BOOST_REQUIRE_LE(1, custom_scheduler<1>::usage_counter());
+}
+
+BOOST_AUTO_TEST_CASE(future_when_all_args_int_with_executor) {
+    BOOST_TEST_MESSAGE("running future when_all int with ready element");
+
+    sut = stlab::when_all(make_executor<1>(), [](auto x, auto y) { return x + y; },
+                             stlab::make_ready_future<int>(42, stlab::immediate_executor),
+                             stlab::make_ready_future<int>(42, stlab::immediate_executor));
 
     check_valid_future(sut);
     wait_until_future_completed(sut);
@@ -70,7 +85,7 @@ BOOST_AUTO_TEST_CASE(future_when_all_args_int_with_ready_element) {
 BOOST_AUTO_TEST_CASE(future_when_all_args_int_with_two_ready_element) {
     BOOST_TEST_MESSAGE("running future when_all int with two ready element");
 
-    sut = when_all(custom_scheduler<1>(), [](auto x, auto y) { return x + y; },
+    sut = when_all(make_executor<1>(), [](auto x, auto y) { return x + y; },
                    make_ready_future<int>(42, immediate_executor),
                    make_ready_future<int>(42, immediate_executor));
 
@@ -84,7 +99,7 @@ BOOST_AUTO_TEST_CASE(future_when_all_args_int_with_two_ready_element) {
 BOOST_AUTO_TEST_CASE(future_when_all_args) {
 
     auto main_thread_id = std::this_thread::get_id();
-    auto sut = when_all(custom_scheduler<1>(), [] { 
+    auto sut = when_all(make_executor<1>(), [] { 
         return std::this_thread::get_id(); 
     }, make_ready_future(stlab::immediate_executor));
 
@@ -100,12 +115,12 @@ BOOST_FIXTURE_TEST_SUITE(future_when_all_args_string, test_fixture<std::string>)
 BOOST_AUTO_TEST_CASE(future_when_all_args_with_different_types) {
     BOOST_TEST_MESSAGE("running future when_all args with different types");
 
-    auto f1 = async(custom_scheduler<0>(), [] { return 1; });
-    auto f2 = async(custom_scheduler<0>(), [] { return 3.1415; });
-    auto f3 = async(custom_scheduler<0>(), [] { return std::string("Don't panic!"); });
-    auto f4 = async(custom_scheduler<0>(), [] { return std::vector<size_t>(2, 3); });
+    auto f1 = async(make_executor<0>(), [] { return 1; });
+    auto f2 = async(make_executor<0>(), [] { return 3.1415; });
+    auto f3 = async(make_executor<0>(), [] { return std::string("Don't panic!"); });
+    auto f4 = async(make_executor<0>(), [] { return std::vector<size_t>(2, 3); });
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [](int x1, double x2, const std::string& x3, const std::vector<size_t>& x4) {
                        std::stringstream st;
                        st << x1 << " " << x2 << " " << x3 << " " << x4[0] << " " << x4[1];
@@ -130,8 +145,8 @@ BOOST_FIXTURE_TEST_SUITE(future_when_all_args_int_failure, test_fixture<int>)
 BOOST_AUTO_TEST_CASE(future_when_all_args_int_failure_with_one_element) {
     BOOST_TEST_MESSAGE("running future when_all int with range of one element");
 
-    auto f1 = async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); });
-    sut = when_all(custom_scheduler<1>(), [](auto x) { return x + x; }, f1);
+    auto f1 = async(make_executor<0>(), []() -> int { throw test_exception("failure"); });
+    sut = when_all(make_executor<1>(), [](auto x) { return x + x; }, f1);
 
     wait_until_future_fails<test_exception>(sut);
 
@@ -143,13 +158,13 @@ BOOST_AUTO_TEST_CASE(future_when_all_args_int_failure_with_one_element) {
 BOOST_AUTO_TEST_CASE(future_when_all_args_int_with_many_elements_one_failing) {
     BOOST_TEST_MESSAGE("running future when_all args int with many elements one failing");
 
-    auto f1 = async(custom_scheduler<0>(), [] { return 1; });
-    auto f2 = async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); });
-    auto f3 = async(custom_scheduler<0>(), [] { return 3; });
-    auto f4 = async(custom_scheduler<0>(), [] { return 5; });
+    auto f1 = async(make_executor<0>(), [] { return 1; });
+    auto f2 = async(make_executor<0>(), []() -> int { throw test_exception("failure"); });
+    auto f3 = async(make_executor<0>(), [] { return 3; });
+    auto f4 = async(make_executor<0>(), [] { return 5; });
 
     sut = when_all(
-        custom_scheduler<1>(),
+        make_executor<1>(),
         [](int x1, int x2, int x3, int x4) { return 7 * x1 + 11 * x2 + 13 * x3 + 17 * x4; }, f1, f2,
         f3, f4);
 
@@ -163,13 +178,13 @@ BOOST_AUTO_TEST_CASE(future_when_all_args_int_with_many_elements_one_failing) {
 BOOST_AUTO_TEST_CASE(future_when_all_args_int_with_many_elements_all_failing) {
     BOOST_TEST_MESSAGE("running future when_all args int with many elements all failing");
 
-    auto f1 = async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); });
-    auto f2 = async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); });
-    auto f3 = async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); });
-    auto f4 = async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); });
+    auto f1 = async(make_executor<0>(), []() -> int { throw test_exception("failure"); });
+    auto f2 = async(make_executor<0>(), []() -> int { throw test_exception("failure"); });
+    auto f3 = async(make_executor<0>(), []() -> int { throw test_exception("failure"); });
+    auto f4 = async(make_executor<0>(), []() -> int { throw test_exception("failure"); });
 
     sut = when_all(
-        custom_scheduler<1>(),
+        make_executor<1>(),
         [](int x1, int x2, int x3, int x4) { return 7 * x1 + 11 * x2 + 13 * x3 + 17 * x4; }, f1, f2,
         f3, f4);
 
@@ -186,13 +201,13 @@ BOOST_FIXTURE_TEST_SUITE(future_when_all_args_string_failure, test_fixture<std::
 BOOST_AUTO_TEST_CASE(future_when_all_args_with_different_types_one_failing) {
     BOOST_TEST_MESSAGE("running future when_all args with different types one failing");
 
-    auto f1 = async(custom_scheduler<0>(), [] { return 1; });
-    auto f2 = async(custom_scheduler<0>(), [] { return 3.1415; });
+    auto f1 = async(make_executor<0>(), [] { return 1; });
+    auto f2 = async(make_executor<0>(), [] { return 3.1415; });
     auto f3 =
-        async(custom_scheduler<0>(), []() -> std::string { throw test_exception("failure"); });
-    auto f4 = async(custom_scheduler<0>(), [] { return std::vector<size_t>(2, 3); });
+        async(make_executor<0>(), []() -> std::string { throw test_exception("failure"); });
+    auto f4 = async(make_executor<0>(), [] { return std::vector<size_t>(2, 3); });
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [](int x1, double x2, const std::string& x3, const std::vector<size_t>& x4) {
                        std::stringstream st;
                        st << x1 << " " << x2 << " " << x3 << " " << x4[0] << " " << x4[1];
@@ -210,14 +225,14 @@ BOOST_AUTO_TEST_CASE(future_when_all_args_with_different_types_one_failing) {
 BOOST_AUTO_TEST_CASE(future_when_all_args_with_different_types_all_failing) {
     BOOST_TEST_MESSAGE("running future when_all args with different types all failing");
 
-    auto f1 = async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); });
-    auto f2 = async(custom_scheduler<0>(), []() -> double { throw test_exception("failure"); });
+    auto f1 = async(make_executor<0>(), []() -> int { throw test_exception("failure"); });
+    auto f2 = async(make_executor<0>(), []() -> double { throw test_exception("failure"); });
     auto f3 =
-        async(custom_scheduler<0>(), []() -> std::string { throw test_exception("failure"); });
-    auto f4 = async(custom_scheduler<0>(),
+        async(make_executor<0>(), []() -> std::string { throw test_exception("failure"); });
+    auto f4 = async(make_executor<0>(),
                     []() -> std::vector<size_t> { throw test_exception("failure"); });
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [](int x1, double x2, const std::string& x3, const std::vector<size_t>& x4) {
                        std::stringstream st;
                        st << x1 << " " << x2 << " " << x3 << " " << x4[0] << " " << x4[1];

--- a/test/future_when_all_range_tests.cpp
+++ b/test/future_when_all_range_tests.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(future_when_all_void_void_empty_range) {
     bool check = {false};
     std::vector<stlab::future<void>> emptyFutures;
 
-    sut = when_all(custom_scheduler<0>(), [& _check = check]() { _check = true; },
+    sut = when_all(make_executor<0>(), [& _check = check]() { _check = true; },
                    std::make_pair(emptyFutures.begin(), emptyFutures.end()));
 
     check_valid_future(sut);
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(future_when_all_void_empty_range) {
     size_t p = 0;
     std::vector<stlab::future<int>> emptyFutures;
 
-    sut = when_all(custom_scheduler<0>(), [& _p = p](std::vector<int> v) { _p = v.size(); },
+    sut = when_all(make_executor<0>(), [& _p = p](std::vector<int> v) { _p = v.size(); },
                    std::make_pair(emptyFutures.begin(), emptyFutures.end()));
 
     check_valid_future(sut);
@@ -54,9 +54,9 @@ BOOST_AUTO_TEST_CASE(future_when_all_void_range_with_one_element) {
     size_t p = 0;
     size_t r = 0;
     std::vector<stlab::future<int>> futures;
-    futures.push_back(async(custom_scheduler<0>(), [] { return 42; }));
+    futures.push_back(async(make_executor<0>(), [] { return 42; }));
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [& _p = p, &_r = r](std::vector<int> v) {
                        _p = v.size();
                        _r = v[0];
@@ -77,12 +77,12 @@ BOOST_AUTO_TEST_CASE(future_when_all_void_range_with_many_elements) {
     size_t p = 0;
     size_t r = 0;
     std::vector<stlab::future<int>> futures;
-    futures.push_back(async(custom_scheduler<0>(), [] { return 1; }));
-    futures.push_back(async(custom_scheduler<0>(), [] { return 2; }));
-    futures.push_back(async(custom_scheduler<0>(), [] { return 3; }));
-    futures.push_back(async(custom_scheduler<0>(), [] { return 5; }));
+    futures.push_back(async(make_executor<0>(), [] { return 1; }));
+    futures.push_back(async(make_executor<0>(), [] { return 2; }));
+    futures.push_back(async(make_executor<0>(), [] { return 3; }));
+    futures.push_back(async(make_executor<0>(), [] { return 5; }));
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [& _p = p, &_r = r](std::vector<int> v) {
                        _p = v.size();
                        for (auto i : v) {
@@ -111,14 +111,14 @@ BOOST_AUTO_TEST_CASE(future_when_all_void_range_with_diamond_formation_elements)
     BOOST_TEST_MESSAGE("running future when_all void with range with diamond formation");
     int v[4] = {0, 0, 0, 0};
     int r = 0;
-    auto start = async(custom_scheduler<0>(), [] { return 4711; });
+    auto start = async(make_executor<0>(), [] { return 4711; });
     std::vector<stlab::future<void>> futures(4);
-    futures[0] = start.then(custom_scheduler<0>(), [& _p = v[0]](auto x) { _p = x + 1; });
-    futures[1] = start.then(custom_scheduler<0>(), [& _p = v[1]](auto x) { _p = x + 2; });
-    futures[2] = start.then(custom_scheduler<0>(), [& _p = v[2]](auto x) { _p = x + 3; });
-    futures[3] = start.then(custom_scheduler<0>(), [& _p = v[3]](auto x) { _p = x + 5; });
+    futures[0] = start.then(make_executor<0>(), [& _p = v[0]](auto x) { _p = x + 1; });
+    futures[1] = start.then(make_executor<0>(), [& _p = v[1]](auto x) { _p = x + 2; });
+    futures[2] = start.then(make_executor<0>(), [& _p = v[2]](auto x) { _p = x + 3; });
+    futures[3] = start.then(make_executor<0>(), [& _p = v[3]](auto x) { _p = x + 5; });
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [& _r = r, &v]() {
                        for (auto i : v) {
                            _r += i;
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(future_when_all_int_empty_range) {
 
     std::vector<stlab::future<int>> emptyFutures;
 
-    sut = when_all(custom_scheduler<0>(),
+    sut = when_all(make_executor<0>(),
                    [](std::vector<int> v) { return static_cast<int>(v.size()); },
                    std::make_pair(emptyFutures.begin(), emptyFutures.end()));
     check_valid_future(sut);
@@ -156,9 +156,9 @@ BOOST_AUTO_TEST_CASE(future_when_all_int_range_with_one_element) {
     BOOST_TEST_MESSAGE("running future when_all int with range of one element");
     size_t p = 0;
     std::vector<stlab::future<int>> futures;
-    futures.push_back(async(custom_scheduler<0>(), [] { return 42; }));
+    futures.push_back(async(make_executor<0>(), [] { return 42; }));
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [& _p = p](std::vector<int> v) {
                        _p = v.size();
                        return v[0];
@@ -178,12 +178,12 @@ BOOST_AUTO_TEST_CASE(future_when_all_int_range_with_many_elements) {
     BOOST_TEST_MESSAGE("running future when_all int with range with many elements");
     size_t p = 0;
     std::vector<stlab::future<int>> futures;
-    futures.push_back(async(custom_scheduler<0>(), [] { return 1; }));
-    futures.push_back(async(custom_scheduler<0>(), [] { return 2; }));
-    futures.push_back(async(custom_scheduler<0>(), [] { return 3; }));
-    futures.push_back(async(custom_scheduler<0>(), [] { return 5; }));
+    futures.push_back(async(make_executor<0>(), [] { return 1; }));
+    futures.push_back(async(make_executor<0>(), [] { return 2; }));
+    futures.push_back(async(make_executor<0>(), [] { return 3; }));
+    futures.push_back(async(make_executor<0>(), [] { return 5; }));
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [& _p = p](std::vector<int> v) {
                        _p = v.size();
                        auto r = 0;
@@ -213,14 +213,14 @@ start           sut
 BOOST_AUTO_TEST_CASE(future_when_all_int_range_with_diamond_formation_elements) {
     BOOST_TEST_MESSAGE("running future when_all int with range with diamond formation");
     size_t p = 0;
-    auto start = async(custom_scheduler<0>(), [] { return 4711; });
+    auto start = async(make_executor<0>(), [] { return 4711; });
     std::vector<stlab::future<int>> futures(4);
-    futures[0] = start.then(custom_scheduler<0>(), [](auto x) { return x + 1; });
-    futures[1] = start.then(custom_scheduler<0>(), [](auto x) { return x + 2; });
-    futures[2] = start.then(custom_scheduler<0>(), [](auto x) { return x + 3; });
-    futures[3] = start.then(custom_scheduler<0>(), [](auto x) { return x + 5; });
+    futures[0] = start.then(make_executor<0>(), [](auto x) { return x + 1; });
+    futures[1] = start.then(make_executor<0>(), [](auto x) { return x + 2; });
+    futures[2] = start.then(make_executor<0>(), [](auto x) { return x + 3; });
+    futures[3] = start.then(make_executor<0>(), [](auto x) { return x + 5; });
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [& _p = p](std::vector<int> v) {
                        _p = v.size();
                        auto r = 0;
@@ -250,12 +250,12 @@ BOOST_AUTO_TEST_CASE(future_when_all_move_range_with_many_elements) {
     BOOST_TEST_MESSAGE("running future when_all move_only with range with many elements");
     size_t p = 0;
     std::vector<stlab::future<stlab::move_only>> futures;
-    futures.push_back(async(custom_scheduler<0>(), [] { return stlab::move_only{1}; }));
-    futures.push_back(async(custom_scheduler<0>(), [] { return stlab::move_only{2}; }));
-    futures.push_back(async(custom_scheduler<0>(), [] { return stlab::move_only{3}; }));
-    futures.push_back(async(custom_scheduler<0>(), [] { return stlab::move_only{5}; }));
+    futures.push_back(async(make_executor<0>(), [] { return stlab::move_only{1}; }));
+    futures.push_back(async(make_executor<0>(), [] { return stlab::move_only{2}; }));
+    futures.push_back(async(make_executor<0>(), [] { return stlab::move_only{3}; }));
+    futures.push_back(async(make_executor<0>(), [] { return stlab::move_only{5}; }));
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [& _p = p](std::vector<stlab::move_only> v) {
                        _p = v.size();
                        auto r = 0;
@@ -287,9 +287,9 @@ BOOST_AUTO_TEST_CASE(future_when_all_void_range_with_one_element) {
     size_t r = 0;
     std::vector<stlab::future<int>> futures;
     futures.push_back(
-        async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); }));
+        async(make_executor<0>(), []() -> int { throw test_exception("failure"); }));
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [& _p = p, &_r = r](const std::vector<int>& v) {
                        _p = v.size();
                        _r = v[0];
@@ -312,12 +312,12 @@ BOOST_AUTO_TEST_CASE(future_when_all_void_range_with_many_elements_one_failing) 
     size_t r = 0;
     std::vector<stlab::future<int>> futures;
     futures.push_back(
-        async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); }));
-    futures.push_back(async(custom_scheduler<0>(), [] { return 2; }));
-    futures.push_back(async(custom_scheduler<0>(), [] { return 3; }));
-    futures.push_back(async(custom_scheduler<0>(), [] { return 5; }));
+        async(make_executor<0>(), []() -> int { throw test_exception("failure"); }));
+    futures.push_back(async(make_executor<0>(), [] { return 2; }));
+    futures.push_back(async(make_executor<0>(), [] { return 3; }));
+    futures.push_back(async(make_executor<0>(), [] { return 5; }));
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [& _p = p, &_r = r](const std::vector<int>& v) {
                        _p = v.size();
                        for (auto i : v) {
@@ -342,15 +342,15 @@ BOOST_AUTO_TEST_CASE(future_when_all_void_range_with_many_elements_all_failing) 
     size_t r = 0;
     std::vector<stlab::future<int>> futures;
     futures.push_back(
-        async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); }));
+        async(make_executor<0>(), []() -> int { throw test_exception("failure"); }));
     futures.push_back(
-        async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); }));
+        async(make_executor<0>(), []() -> int { throw test_exception("failure"); }));
     futures.push_back(
-        async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); }));
+        async(make_executor<0>(), []() -> int { throw test_exception("failure"); }));
     futures.push_back(
-        async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); }));
+        async(make_executor<0>(), []() -> int { throw test_exception("failure"); }));
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [& _p = p, &_r = r](const std::vector<int>& v) {
                        _p = v.size();
                        for (auto i : v) {
@@ -380,14 +380,14 @@ BOOST_AUTO_TEST_CASE(future_when_all_void_range_with_diamond_formation_elements_
         "running future when_all void with range with diamond formation and start failing");
     int v[4] = {0, 0, 0, 0};
     int r = 0;
-    auto start = async(custom_scheduler<0>(), []() -> int { throw test_exception("failure"); });
+    auto start = async(make_executor<0>(), []() -> int { throw test_exception("failure"); });
     std::vector<stlab::future<void>> futures(4);
-    futures[0] = start.then(custom_scheduler<0>(), [& _p = v[0]](auto x) { _p = x + 1; });
-    futures[1] = start.then(custom_scheduler<0>(), [& _p = v[1]](auto x) { _p = x + 2; });
-    futures[2] = start.then(custom_scheduler<0>(), [& _p = v[2]](auto x) { _p = x + 3; });
-    futures[3] = start.then(custom_scheduler<0>(), [& _p = v[3]](auto x) { _p = x + 5; });
+    futures[0] = start.then(make_executor<0>(), [& _p = v[0]](auto x) { _p = x + 1; });
+    futures[1] = start.then(make_executor<0>(), [& _p = v[1]](auto x) { _p = x + 2; });
+    futures[2] = start.then(make_executor<0>(), [& _p = v[2]](auto x) { _p = x + 3; });
+    futures[3] = start.then(make_executor<0>(), [& _p = v[3]](auto x) { _p = x + 5; });
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [& _r = r, &v]() {
                        for (auto i : v) {
                            _r += i;
@@ -412,14 +412,14 @@ BOOST_AUTO_TEST_CASE(
         "running future when_all void with range with diamond formation and one of the parallel tasks is failing");
     int v[4] = {0, 0, 0, 0};
     int r = 0;
-    auto start = async(custom_scheduler<0>(), []() -> int { return 42; });
+    auto start = async(make_executor<0>(), []() -> int { return 42; });
     std::vector<stlab::future<void>> futures(4);
-    futures[0] = start.then(custom_scheduler<0>(), [& _p = v[0]](auto x) { _p = x + 1; });
-    futures[1] = start.then(custom_scheduler<0>(), [](auto) { throw test_exception("failure"); });
-    futures[2] = start.then(custom_scheduler<0>(), [& _p = v[2]](auto x) { _p = x + 3; });
-    futures[3] = start.then(custom_scheduler<0>(), [& _p = v[3]](auto x) { _p = x + 5; });
+    futures[0] = start.then(make_executor<0>(), [& _p = v[0]](auto x) { _p = x + 1; });
+    futures[1] = start.then(make_executor<0>(), [](auto) { throw test_exception("failure"); });
+    futures[2] = start.then(make_executor<0>(), [& _p = v[2]](auto x) { _p = x + 3; });
+    futures[3] = start.then(make_executor<0>(), [& _p = v[3]](auto x) { _p = x + 5; });
 
-    sut = when_all(custom_scheduler<1>(),
+    sut = when_all(make_executor<1>(),
                    [& _r = r, &v]() {
                        for (auto i : v) {
                            _r += i;
@@ -440,14 +440,14 @@ BOOST_AUTO_TEST_CASE(future_when_all_void_range_with_diamond_formation_elements_
         "running future when_all void with range with diamond formation and the joining tasks is failing");
     int v[4] = {0, 0, 0, 0};
     int r = 0;
-    auto start = async(custom_scheduler<0>(), []() -> int { return 42; });
+    auto start = async(make_executor<0>(), []() -> int { return 42; });
     std::vector<stlab::future<void>> futures(4);
-    futures[0] = start.then(custom_scheduler<0>(), [& _p = v[0]](auto x) { _p = x + 1; });
-    futures[1] = start.then(custom_scheduler<0>(), [& _p = v[1]](auto x) { _p = x + 2; });
-    futures[2] = start.then(custom_scheduler<0>(), [& _p = v[2]](auto x) { _p = x + 3; });
-    futures[3] = start.then(custom_scheduler<0>(), [& _p = v[3]](auto x) { _p = x + 5; });
+    futures[0] = start.then(make_executor<0>(), [& _p = v[0]](auto x) { _p = x + 1; });
+    futures[1] = start.then(make_executor<0>(), [& _p = v[1]](auto x) { _p = x + 2; });
+    futures[2] = start.then(make_executor<0>(), [& _p = v[2]](auto x) { _p = x + 3; });
+    futures[3] = start.then(make_executor<0>(), [& _p = v[3]](auto x) { _p = x + 5; });
 
-    sut = when_all(custom_scheduler<1>(), []() { throw test_exception("failure"); },
+    sut = when_all(make_executor<1>(), []() { throw test_exception("failure"); },
                    std::make_pair(futures.begin(), futures.end()));
 
     wait_until_future_fails<test_exception>(sut);

--- a/test/future_when_any_arguments_tests.cpp
+++ b/test/future_when_any_arguments_tests.cpp
@@ -26,9 +26,9 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_range_with_one_argument) {
     BOOST_TEST_MESSAGE("running future when_any int void with range of one argument");
     size_t index = 4711;
     size_t result = 0;
-    auto a1 = async(custom_scheduler<0>(), [] { return 42; });
+    auto a1 = async(make_executor<0>(), [] { return 42; });
 
-    sut = when_any(custom_scheduler<1>(),
+    sut = when_any(make_executor<1>(),
                    [& _i = index, &_r = result](int x, size_t index) {
                        _i = index;
                        _r = x;
@@ -53,22 +53,22 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_range_with_many_arguments_first_su
     size_t used_future_index = 0;
     size_t result = 0;
 
-    auto a1 = async(custom_scheduler<0>(), make_non_blocking_functor(
+    auto a1 = async(make_executor<0>(), make_non_blocking_functor(
                                                [& _context = block_context]() {
                                                    _context._may_proceed = true;
                                                    return 1;
                                                },
                                                _task_counter));
-    auto a2 = async(custom_scheduler<0>(),
+    auto a2 = async(make_executor<0>(),
                     make_blocking_functor([] { return 2; }, _task_counter, block_context));
-    auto a3 = async(custom_scheduler<0>(),
+    auto a3 = async(make_executor<0>(),
                     make_blocking_functor([] { return 3; }, _task_counter, block_context));
-    auto a4 = async(custom_scheduler<0>(),
+    auto a4 = async(make_executor<0>(),
                     make_blocking_functor([] { return 5; }, _task_counter, block_context));
     {
         lock_t block(*block_context._mutex);
 
-        sut = when_any(custom_scheduler<1>(),
+        sut = when_any(make_executor<1>(),
                        [& _r = result, &_used_future_index = used_future_index,
                         &_counter = any_task_execution_counter](int x, size_t index) {
                            _used_future_index = index;
@@ -101,23 +101,23 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_argument_with_many_arguments_middl
     size_t used_future_index = 0;
     size_t result = 0;
 
-    auto a1 = async(custom_scheduler<0>(),
+    auto a1 = async(make_executor<0>(),
                     make_blocking_functor([] { return 1; }, _task_counter, block_context));
-    auto a2 = async(custom_scheduler<0>(),
+    auto a2 = async(make_executor<0>(),
                     make_blocking_functor([] { return 2; }, _task_counter, block_context));
-    auto a3 = async(custom_scheduler<0>(), make_non_blocking_functor(
+    auto a3 = async(make_executor<0>(), make_non_blocking_functor(
                                                [& _context = block_context] {
                                                    _context._may_proceed = true;
                                                    return 3;
                                                },
                                                _task_counter));
-    auto a4 = async(custom_scheduler<0>(),
+    auto a4 = async(make_executor<0>(),
                     make_blocking_functor([] { return 5; }, _task_counter, block_context));
 
     {
         lock_t lock(*block_context._mutex);
 
-        sut = when_any(custom_scheduler<1>(),
+        sut = when_any(make_executor<1>(),
                        [& _r = result, &_used_future_index = used_future_index,
                         &_counter = any_task_execution_counter](int x, size_t index) {
                            _used_future_index = index;
@@ -150,13 +150,13 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_argument_with_many_arguments_last_
     size_t used_future_index = 0;
     size_t result = 0;
 
-    auto a1 = async(custom_scheduler<0>(),
+    auto a1 = async(make_executor<0>(),
                     make_blocking_functor([] { return 1; }, _task_counter, block_context));
-    auto a2 = async(custom_scheduler<0>(),
+    auto a2 = async(make_executor<0>(),
                     make_blocking_functor([] { return 2; }, _task_counter, block_context));
-    auto a3 = async(custom_scheduler<0>(),
+    auto a3 = async(make_executor<0>(),
                     make_blocking_functor([] { return 3; }, _task_counter, block_context));
-    auto a4 = async(custom_scheduler<0>(), make_non_blocking_functor(
+    auto a4 = async(make_executor<0>(), make_non_blocking_functor(
                                                [& _context = block_context] {
                                                    _context._may_proceed = true;
                                                    return 5;
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_argument_with_many_arguments_last_
     {
         lock_t lock(*block_context._mutex);
 
-        sut = when_any(custom_scheduler<1>(),
+        sut = when_any(make_executor<1>(),
                        [& _r = result, &_used_future_index = used_future_index,
                         &_counter = any_task_execution_counter](int x, size_t index) {
                            _used_future_index = index;
@@ -198,13 +198,13 @@ BOOST_AUTO_TEST_CASE(
     size_t index = 4711;
     int result = 0;
 
-    auto a1 = async(custom_scheduler<0>(), make_failing_functor([] { return 1; }, _task_counter));
-    auto a2 = async(custom_scheduler<0>(), make_failing_functor([] { return 1; }, _task_counter));
+    auto a1 = async(make_executor<0>(), make_failing_functor([] { return 1; }, _task_counter));
+    auto a2 = async(make_executor<0>(), make_failing_functor([] { return 1; }, _task_counter));
     auto a3 =
-        async(custom_scheduler<0>(), make_non_blocking_functor([] { return 3; }, _task_counter));
-    auto a4 = async(custom_scheduler<0>(), make_failing_functor([] { return 1; }, _task_counter));
+        async(make_executor<0>(), make_non_blocking_functor([] { return 3; }, _task_counter));
+    auto a4 = async(make_executor<0>(), make_failing_functor([] { return 1; }, _task_counter));
 
-    sut = when_any(custom_scheduler<1>(),
+    sut = when_any(make_executor<1>(),
                    [& _i = index, &_result = result,
                     &_counter = any_task_execution_counter](int x, size_t index) {
                        ++_counter;
@@ -230,12 +230,12 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_arguments_with_many_arguments_all_
     size_t index = 4711;
     int r = 0;
 
-    auto a1 = async(custom_scheduler<0>(), make_failing_functor([] { return 0; }, _task_counter));
-    auto a2 = async(custom_scheduler<0>(), make_failing_functor([] { return 0; }, _task_counter));
-    auto a3 = async(custom_scheduler<0>(), make_failing_functor([] { return 0; }, _task_counter));
-    auto a4 = async(custom_scheduler<0>(), make_failing_functor([] { return 0; }, _task_counter));
+    auto a1 = async(make_executor<0>(), make_failing_functor([] { return 0; }, _task_counter));
+    auto a2 = async(make_executor<0>(), make_failing_functor([] { return 0; }, _task_counter));
+    auto a3 = async(make_executor<0>(), make_failing_functor([] { return 0; }, _task_counter));
+    auto a4 = async(make_executor<0>(), make_failing_functor([] { return 0; }, _task_counter));
 
-    sut = when_any(custom_scheduler<1>(),
+    sut = when_any(make_executor<1>(),
                    [& _i = index, &_r = r](int x, size_t index) {
                        _i = index;
                        _r = x;
@@ -258,9 +258,9 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_int_argument_with_one_argument) {
     BOOST_TEST_MESSAGE("running future when_any int int arguments of one argument");
     size_t index = 42;
 
-    auto a1 = async(custom_scheduler<0>(), [] { return 4711; });
+    auto a1 = async(make_executor<0>(), [] { return 4711; });
 
-    sut = when_any(custom_scheduler<1>(),
+    sut = when_any(make_executor<1>(),
                    [& _i = index](int x, size_t index) {
                        _i = index;
                        return x;
@@ -285,13 +285,13 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_int_arguments_with_many_arguments_last_
     std::atomic_int any_task_execution_counter{0};
     size_t used_future_index = 0;
 
-    auto a1 = async(custom_scheduler<0>(),
+    auto a1 = async(make_executor<0>(),
                     make_blocking_functor([] { return 42; }, _task_counter, block_context));
-    auto a2 = async(custom_scheduler<0>(),
+    auto a2 = async(make_executor<0>(),
                     make_blocking_functor([] { return 815; }, _task_counter, block_context));
-    auto a3 = async(custom_scheduler<0>(),
+    auto a3 = async(make_executor<0>(),
                     make_blocking_functor([] { return 4711; }, _task_counter, block_context));
-    auto a4 = async(custom_scheduler<0>(), make_non_blocking_functor(
+    auto a4 = async(make_executor<0>(), make_non_blocking_functor(
                                                [& _context = block_context] {
                                                    _context._may_proceed = true;
                                                    return 5;
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_int_arguments_with_many_arguments_last_
 
     {
         lock_t lock(*block_context._mutex);
-        sut = when_any(custom_scheduler<1>(),
+        sut = when_any(make_executor<1>(),
                        [& _used_future_index = used_future_index,
                         &_counter = any_task_execution_counter](int x, size_t index) {
                            _used_future_index = index;
@@ -329,28 +329,28 @@ BOOST_AUTO_TEST_CASE(
     size_t index = 0;
     std::atomic_int failures{0};
 
-    auto a1 = async(custom_scheduler<0>(), make_failing_functor(
+    auto a1 = async(make_executor<0>(), make_failing_functor(
                                                [& _f = failures]() -> int {
                                                    ++_f;
                                                    return 0;
                                                },
                                                _task_counter));
-    auto a2 = async(custom_scheduler<0>(), make_failing_functor(
+    auto a2 = async(make_executor<0>(), make_failing_functor(
                                                [& _f = failures]() -> int {
                                                    ++_f;
                                                    return 0;
                                                },
                                                _task_counter));
-    auto a3 = async(custom_scheduler<0>(),
+    auto a3 = async(make_executor<0>(),
                     make_non_blocking_functor([]() -> int { return 3; }, _task_counter));
-    auto a4 = async(custom_scheduler<0>(), make_failing_functor(
+    auto a4 = async(make_executor<0>(), make_failing_functor(
                                                [& _f = failures]() -> int {
                                                    ++_f;
                                                    return 0;
                                                },
                                                _task_counter));
 
-    sut = when_any(custom_scheduler<1>(),
+    sut = when_any(make_executor<1>(),
                    [& _index = index](int x, size_t index) {
                        _index = index;
                        return x;
@@ -383,25 +383,25 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_arguments_with_diamond_formation_argume
     size_t index = 0;
     {
         lock_t lock(*block_context._mutex);
-        auto start = async(custom_scheduler<0>(), [] { return 4711; });
+        auto start = async(make_executor<0>(), [] { return 4711; });
 
         auto a1 =
-            start.then(custom_scheduler<0>(), make_blocking_functor([](int x) { return x + 1; },
+            start.then(make_executor<0>(), make_blocking_functor([](int x) { return x + 1; },
                                                                     _task_counter, block_context));
-        auto a2 = start.then(custom_scheduler<0>(), make_non_blocking_functor(
+        auto a2 = start.then(make_executor<0>(), make_non_blocking_functor(
                                                         [& _context = block_context](auto x) {
                                                             _context._may_proceed = true;
                                                             return x + 2;
                                                         },
                                                         _task_counter));
         auto a3 =
-            start.then(custom_scheduler<0>(), make_blocking_functor([](int x) { return x + 3; },
+            start.then(make_executor<0>(), make_blocking_functor([](int x) { return x + 3; },
                                                                     _task_counter, block_context));
         auto a4 =
-            start.then(custom_scheduler<0>(), make_blocking_functor([](int x) { return x + 5; },
+            start.then(make_executor<0>(), make_blocking_functor([](int x) { return x + 5; },
                                                                     _task_counter, block_context));
 
-        sut = when_any(custom_scheduler<1>(),
+        sut = when_any(make_executor<1>(),
                        [& _i = index](int x, size_t index) {
                            _i = index;
                            return x;

--- a/test/future_when_any_range_tests.cpp
+++ b/test/future_when_any_range_tests.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(future_when_any_void_void_empty_range) {
     bool check{false};
     std::vector<stlab::future<void>> emptyFutures;
 
-    sut = when_any(custom_scheduler<0>(), [& _check = check](size_t) { _check = true; },
+    sut = when_any(make_executor<0>(), [& _check = check](size_t) { _check = true; },
                    std::make_pair(emptyFutures.begin(), emptyFutures.end()));
 
     wait_until_future_fails<stlab::future_error>(sut);
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_empty_range) {
     bool check{false};
     std::vector<stlab::future<int>> emptyFutures;
 
-    sut = when_any(custom_scheduler<0>(), [& _check = check](int, size_t) { _check = true; },
+    sut = when_any(make_executor<0>(), [& _check = check](int, size_t) { _check = true; },
                    std::make_pair(emptyFutures.begin(), emptyFutures.end()));
 
     wait_until_future_fails<stlab::future_error>(sut);
@@ -57,10 +57,10 @@ BOOST_AUTO_TEST_CASE(future_when_any_void_void_range_with_one_element) {
     int interim_result = 0;
     int result = 0;
     std::vector<stlab::future<void>> futures;
-    futures.push_back(async(custom_scheduler<0>(),
+    futures.push_back(async(make_executor<0>(),
                             [& _interim_result = interim_result] { _interim_result = 42; }));
 
-    sut = when_any(custom_scheduler<1>(),
+    sut = when_any(make_executor<1>(),
                    [& _result = result, &_interim_result = interim_result](size_t) {
                        _result = _interim_result;
                    },
@@ -78,9 +78,9 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_range_with_one_element) {
     size_t index = 4711;
     size_t result = 0;
     std::vector<stlab::future<int>> futures;
-    futures.push_back(async(custom_scheduler<0>(), [] { return 42; }));
+    futures.push_back(async(make_executor<0>(), [] { return 42; }));
 
-    sut = when_any(custom_scheduler<1>(),
+    sut = when_any(make_executor<1>(),
                    [& _i = index, &_r = result](int x, size_t index) {
                        _i = index;
                        _r = x;
@@ -106,22 +106,22 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_range_with_many_elements_first_suc
     size_t result = 0;
 
     std::vector<stlab::future<int>> futures;
-    futures.push_back(async(custom_scheduler<0>(), make_non_blocking_functor(
+    futures.push_back(async(make_executor<0>(), make_non_blocking_functor(
                                                        [& _context = block_context]() {
                                                            _context._may_proceed = true;
                                                            return 1;
                                                        },
                                                        _task_counter)));
-    futures.push_back(async(custom_scheduler<0>(),
+    futures.push_back(async(make_executor<0>(),
                             make_blocking_functor([] { return 2; }, _task_counter, block_context)));
-    futures.push_back(async(custom_scheduler<0>(),
+    futures.push_back(async(make_executor<0>(),
                             make_blocking_functor([] { return 3; }, _task_counter, block_context)));
-    futures.push_back(async(custom_scheduler<0>(),
+    futures.push_back(async(make_executor<0>(),
                             make_blocking_functor([] { return 5; }, _task_counter, block_context)));
     {
         lock_t block(*block_context._mutex);
 
-        sut = when_any(custom_scheduler<1>(),
+        sut = when_any(make_executor<1>(),
                        [& _r = result, &_used_future_index = used_future_index,
                         &_counter = any_task_execution_counter](int x, size_t index) {
                            _used_future_index = index;
@@ -154,23 +154,23 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_range_with_many_elements_middle_su
     size_t result = 0;
 
     std::vector<stlab::future<int>> futures;
-    futures.push_back(async(custom_scheduler<0>(),
+    futures.push_back(async(make_executor<0>(),
                             make_blocking_functor([] { return 1; }, _task_counter, block_context)));
-    futures.push_back(async(custom_scheduler<0>(),
+    futures.push_back(async(make_executor<0>(),
                             make_blocking_functor([] { return 2; }, _task_counter, block_context)));
-    futures.push_back(async(custom_scheduler<0>(), make_non_blocking_functor(
+    futures.push_back(async(make_executor<0>(), make_non_blocking_functor(
                                                        [& _context = block_context] {
                                                            _context._may_proceed = true;
                                                            return 3;
                                                        },
                                                        _task_counter)));
-    futures.push_back(async(custom_scheduler<0>(),
+    futures.push_back(async(make_executor<0>(),
                             make_blocking_functor([] { return 5; }, _task_counter, block_context)));
 
     {
         lock_t lock(*block_context._mutex);
 
-        sut = when_any(custom_scheduler<1>(),
+        sut = when_any(make_executor<1>(),
                        [& _r = result, &_used_future_index = used_future_index,
                         &_counter = any_task_execution_counter](int x, size_t index) {
                            _used_future_index = index;
@@ -204,13 +204,13 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_range_with_many_elements_last_succ
     size_t result = 0;
 
     std::vector<stlab::future<int>> futures;
-    futures.push_back(async(custom_scheduler<0>(),
+    futures.push_back(async(make_executor<0>(),
                             make_blocking_functor([] { return 1; }, _task_counter, block_context)));
-    futures.push_back(async(custom_scheduler<0>(),
+    futures.push_back(async(make_executor<0>(),
                             make_blocking_functor([] { return 2; }, _task_counter, block_context)));
-    futures.push_back(async(custom_scheduler<0>(),
+    futures.push_back(async(make_executor<0>(),
                             make_blocking_functor([] { return 3; }, _task_counter, block_context)));
-    futures.push_back(async(custom_scheduler<0>(), make_non_blocking_functor(
+    futures.push_back(async(make_executor<0>(), make_non_blocking_functor(
                                                        [& _context = block_context] {
                                                            _context._may_proceed = true;
                                                            return 5;
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_range_with_many_elements_last_succ
     {
         lock_t lock(*block_context._mutex);
 
-        sut = when_any(custom_scheduler<1>(),
+        sut = when_any(make_executor<1>(),
                        [& _r = result, &_used_future_index = used_future_index,
                         &_counter = any_task_execution_counter](int x, size_t index) {
                            _used_future_index = index;
@@ -254,15 +254,15 @@ BOOST_AUTO_TEST_CASE(
 
     std::vector<stlab::future<int>> futures;
     futures.push_back(
-        async(custom_scheduler<0>(), make_failing_functor([] { return 1; }, _task_counter)));
+        async(make_executor<0>(), make_failing_functor([] { return 1; }, _task_counter)));
     futures.push_back(
-        async(custom_scheduler<0>(), make_failing_functor([] { return 1; }, _task_counter)));
+        async(make_executor<0>(), make_failing_functor([] { return 1; }, _task_counter)));
     futures.push_back(
-        async(custom_scheduler<0>(), make_non_blocking_functor([] { return 3; }, _task_counter)));
+        async(make_executor<0>(), make_non_blocking_functor([] { return 3; }, _task_counter)));
     futures.push_back(
-        async(custom_scheduler<0>(), make_failing_functor([] { return 1; }, _task_counter)));
+        async(make_executor<0>(), make_failing_functor([] { return 1; }, _task_counter)));
 
-    sut = when_any(custom_scheduler<1>(),
+    sut = when_any(make_executor<1>(),
                    [& _i = index, &_result = result,
                     &_counter = any_task_execution_counter](int x, size_t index) {
                        ++_counter;
@@ -290,15 +290,15 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_void_range_with_many_elements_all_fails
 
     std::vector<stlab::future<int>> futures;
     futures.push_back(
-        async(custom_scheduler<0>(), make_failing_functor([] { return 0; }, _task_counter)));
+        async(make_executor<0>(), make_failing_functor([] { return 0; }, _task_counter)));
     futures.push_back(
-        async(custom_scheduler<0>(), make_failing_functor([] { return 0; }, _task_counter)));
+        async(make_executor<0>(), make_failing_functor([] { return 0; }, _task_counter)));
     futures.push_back(
-        async(custom_scheduler<0>(), make_failing_functor([] { return 0; }, _task_counter)));
+        async(make_executor<0>(), make_failing_functor([] { return 0; }, _task_counter)));
     futures.push_back(
-        async(custom_scheduler<0>(), make_failing_functor([] { return 0; }, _task_counter)));
+        async(make_executor<0>(), make_failing_functor([] { return 0; }, _task_counter)));
 
-    sut = when_any(custom_scheduler<1>(),
+    sut = when_any(make_executor<1>(),
                    [& _i = index, &_r = r](int x, size_t index) {
                        _i = index;
                        _r = x;
@@ -332,22 +332,22 @@ BOOST_AUTO_TEST_CASE(future_when_any_void_range_with_diamond_formation_elements)
 
     {
         lock_t block(*block_context._mutex);
-        auto start = async(custom_scheduler<0>(), [] { return 4711; });
+        auto start = async(make_executor<0>(), [] { return 4711; });
         std::vector<future<void>> futures;
         futures.push_back(start.then(
-            custom_scheduler<0>(),
+            make_executor<0>(),
             make_blocking_functor([& _result = intrim_results](auto x) { _result[0] = x + 1; },
                                   _task_counter, block_context)));
         futures.push_back(start.then(
-            custom_scheduler<0>(),
+            make_executor<0>(),
             make_blocking_functor([& _result = intrim_results](auto x) { _result[1] = x + 2; },
                                   _task_counter, block_context)));
         futures.push_back(start.then(
-            custom_scheduler<0>(),
+            make_executor<0>(),
             make_blocking_functor([& _result = intrim_results](auto x) { _result[2] = x + 3; },
                                   _task_counter, block_context)));
         futures.push_back(
-            start.then(custom_scheduler<0>(),
+            start.then(make_executor<0>(),
                        make_non_blocking_functor(
                            [& _context = block_context, &_result = intrim_results](auto x) {
                                _result[3] = x;
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(future_when_any_void_range_with_diamond_formation_elements)
                            },
                            _task_counter)));
 
-        sut = when_any(custom_scheduler<1>(),
+        sut = when_any(make_executor<1>(),
                        [& _result = result, &_counter = any_task_execution_counter,
                         &_interim_results = intrim_results](size_t index) {
                            _result = _interim_results[index];
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_int_empty_range) {
 
     bool check{false};
     std::vector<stlab::future<int>> emptyFutures;
-    sut = when_any(custom_scheduler<0>(),
+    sut = when_any(make_executor<0>(),
                    [& _check = check](int x, size_t) {
                        _check = true;
                        return x + 42;
@@ -401,9 +401,9 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_int_range_with_one_element) {
     size_t index = 42;
 
     std::vector<stlab::future<int>> futures;
-    futures.push_back(async(custom_scheduler<0>(), [] { return 4711; }));
+    futures.push_back(async(make_executor<0>(), [] { return 4711; }));
 
-    sut = when_any(custom_scheduler<1>(),
+    sut = when_any(make_executor<1>(),
                    [& _i = index](int x, size_t index) {
                        _i = index;
                        return x;
@@ -431,15 +431,15 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_int_range_with_many_elements) {
 
     std::vector<stlab::future<int>> futures;
     futures.push_back(
-        async(custom_scheduler<0>(),
+        async(make_executor<0>(),
               make_blocking_functor([] { return 42; }, _task_counter, block_context)));
     futures.push_back(
-        async(custom_scheduler<0>(),
+        async(make_executor<0>(),
               make_blocking_functor([] { return 815; }, _task_counter, block_context)));
     futures.push_back(
-        async(custom_scheduler<0>(),
+        async(make_executor<0>(),
               make_blocking_functor([] { return 4711; }, _task_counter, block_context)));
-    futures.push_back(async(custom_scheduler<0>(), make_non_blocking_functor(
+    futures.push_back(async(make_executor<0>(), make_non_blocking_functor(
                                                        [& _context = block_context] {
                                                            _context._may_proceed = true;
                                                            return 5;
@@ -448,7 +448,7 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_int_range_with_many_elements) {
 
     {
         lock_t lock(*block_context._mutex);
-        sut = when_any(custom_scheduler<1>(),
+        sut = when_any(make_executor<1>(),
                        [& _used_future_index = used_future_index,
                         &_counter = any_task_execution_counter](int x, size_t index) {
                            _used_future_index = index;
@@ -476,28 +476,28 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_int_range_with_many_elements_all_but_al
     size_t index = 0;
     std::atomic_int failures{0};
     std::vector<stlab::future<int>> futures;
-    futures.push_back(async(custom_scheduler<0>(), make_failing_functor(
+    futures.push_back(async(make_executor<0>(), make_failing_functor(
                                                        [& _f = failures]() -> int {
                                                            ++_f;
                                                            return 0;
                                                        },
                                                        _task_counter)));
-    futures.push_back(async(custom_scheduler<0>(), make_failing_functor(
+    futures.push_back(async(make_executor<0>(), make_failing_functor(
                                                        [& _f = failures]() -> int {
                                                            ++_f;
                                                            return 0;
                                                        },
                                                        _task_counter)));
-    futures.push_back(async(custom_scheduler<0>(),
+    futures.push_back(async(make_executor<0>(),
                             make_non_blocking_functor([]() -> int { return 3; }, _task_counter)));
-    futures.push_back(async(custom_scheduler<0>(), make_failing_functor(
+    futures.push_back(async(make_executor<0>(), make_failing_functor(
                                                        [& _f = failures]() -> int {
                                                            ++_f;
                                                            return 0;
                                                        },
                                                        _task_counter)));
 
-    sut = when_any(custom_scheduler<1>(),
+    sut = when_any(make_executor<1>(),
                    [& _index = index](int x, size_t index) {
                        _index = index;
                        return x;
@@ -530,26 +530,26 @@ BOOST_AUTO_TEST_CASE(future_when_any_int_range_with_diamond_formation_elements) 
     size_t index = 0;
     {
         lock_t lock(*block_context._mutex);
-        auto start = async(custom_scheduler<0>(), [] { return 4711; });
+        auto start = async(make_executor<0>(), [] { return 4711; });
         std::vector<stlab::future<int>> futures;
         futures.push_back(
-            start.then(custom_scheduler<0>(), make_blocking_functor([](int x) { return x + 1; },
+            start.then(make_executor<0>(), make_blocking_functor([](int x) { return x + 1; },
                                                                     _task_counter, block_context)));
         futures.push_back(
-            start.then(custom_scheduler<0>(), make_non_blocking_functor(
+            start.then(make_executor<0>(), make_non_blocking_functor(
                                                   [& _context = block_context](auto x) {
                                                       _context._may_proceed = true;
                                                       return x + 2;
                                                   },
                                                   _task_counter)));
         futures.push_back(
-            start.then(custom_scheduler<0>(), make_blocking_functor([](int x) { return x + 3; },
+            start.then(make_executor<0>(), make_blocking_functor([](int x) { return x + 3; },
                                                                     _task_counter, block_context)));
         futures.push_back(
-            start.then(custom_scheduler<0>(), make_blocking_functor([](int x) { return x + 5; },
+            start.then(make_executor<0>(), make_blocking_functor([](int x) { return x + 5; },
                                                                     _task_counter, block_context)));
 
-        sut = when_any(custom_scheduler<1>(),
+        sut = when_any(make_executor<1>(),
                        [& _i = index](int x, size_t index) {
                            _i = index;
                            return x;
@@ -583,26 +583,26 @@ BOOST_AUTO_TEST_CASE(future_when_any_move_only_range_with_diamond_formation_elem
   size_t index = 0;
   {
     lock_t lock(*block_context._mutex);
-    auto start = async(custom_scheduler<0>(), [] { return 4711; });
+    auto start = async(make_executor<0>(), [] { return 4711; });
     std::vector<stlab::future<stlab::move_only>> futures;
     futures.push_back(
-      start.then(custom_scheduler<0>(), make_blocking_functor([](int x) { return stlab::move_only{ x + 1 }; },
+      start.then(make_executor<0>(), make_blocking_functor([](int x) { return stlab::move_only{ x + 1 }; },
         _task_counter, block_context)));
     futures.push_back(
-      start.then(custom_scheduler<0>(), make_non_blocking_functor(
+      start.then(make_executor<0>(), make_non_blocking_functor(
         [&_context = block_context](auto x) {
       _context._may_proceed = true;
       return stlab::move_only{ x + 2 };
     },
         _task_counter)));
     futures.push_back(
-      start.then(custom_scheduler<0>(), make_blocking_functor([](int x) { return stlab::move_only{ x + 3 }; },
+      start.then(make_executor<0>(), make_blocking_functor([](int x) { return stlab::move_only{ x + 3 }; },
         _task_counter, block_context)));
     futures.push_back(
-      start.then(custom_scheduler<0>(), make_blocking_functor([](int x) { return stlab::move_only{ x + 5 }; },
+      start.then(make_executor<0>(), make_blocking_functor([](int x) { return stlab::move_only{ x + 5 }; },
         _task_counter, block_context)));
 
-    sut = when_any(custom_scheduler<1>(),
+    sut = when_any(make_executor<1>(),
       [&_i = index](stlab::move_only x, size_t index) {
       _i = index;
       return x;


### PR DESCRIPTION
This fixes the UB in the context of executors with non-trivial members and the usage of when_all and when_any.