### PR TITLE
Fix197

### DIFF
--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -144,7 +144,7 @@ class task_system {
             if (_pool == nullptr) throw std::bad_alloc();
             
             _cleanupgroup = CreateThreadpoolCleanupGroup();
-            if (_pool == nullptr) throw std::bad_alloc();
+            if (_cleanupgroup == nullptr) throw std::bad_alloc();
             
             SetThreadpoolCallbackPool(&_callBackEnvironment, _pool);
             SetThreadpoolCallbackCleanupGroup(&_callBackEnvironment, _cleanupgroup, nullptr);

--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -17,7 +17,6 @@
 
 #if STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_LIBDISPATCH
 #include <dispatch/dispatch.h>
-#include <stlab/concurrency/task.hpp>
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_EMSCRIPTEN
 #include <emscripten.h>
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_PNACL
@@ -27,7 +26,6 @@
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_WINDOWS
 #include <Windows.h>
 #include <memory>
-#include <stlab/concurrency/task.hpp>
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_PORTABLE
 #include <algorithm>
 #include <atomic>
@@ -35,8 +33,6 @@
 #include <deque>
 #include <thread>
 #include <vector>
-
-#include <stlab/concurrency/task.hpp>
 
 // REVISIT (sparent) : for testing only
 #if 0 && __APPLE__

--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -62,7 +62,9 @@ class task_system {
         dispatch_group_t _group = dispatch_group_create();
         ~model() {
             dispatch_group_wait(_group, DISPATCH_TIME_FOREVER);
+#if !__has_feature(objc_arc)
             dispatch_release(_group);
+#endif
         }
         
         template <typename F>

--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -17,6 +17,7 @@
 
 #if STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_LIBDISPATCH
 #include <dispatch/dispatch.h>
+#include <stlab/concurrency/task.hpp>
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_EMSCRIPTEN
 #include <emscripten.h>
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_PNACL
@@ -26,6 +27,7 @@
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_WINDOWS
 #include <Windows.h>
 #include <memory>
+#include <stlab/concurrency/task.hpp>
 #elif STLAB_TASK_SYSTEM == STLAB_TASK_SYSTEM_PORTABLE
 #include <algorithm>
 #include <atomic>

--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -284,9 +284,8 @@ class task_system {
     
 public:
     
-    template <typename F>
-    void operator()(F&& f) {
-        (*_self)(std::forward<F>(f));
+    void operator()(task<void()> f) {
+        (*_self)([f = std::move(f), retain = _self]() mutable { f(); });
     }
 };
 
@@ -300,7 +299,7 @@ struct default_executor_type {
 
     void operator()(task<void()> f) const {
         static task_system only_task_system;
-        only_task_system([f = std::move(f), retain = only_task_system]() mutable { f(); });
+        only_task_system(std::move(f));
     }
 };
 

--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -144,7 +144,10 @@ class task_system {
             if (_pool == nullptr) throw std::bad_alloc();
             
             _cleanupgroup = CreateThreadpoolCleanupGroup();
-            if (_cleanupgroup == nullptr) throw std::bad_alloc();
+            if (_cleanupgroup == nullptr) {
+                CloseThreadpool(_pool);
+                throw std::bad_alloc();
+            }
             
             SetThreadpoolCallbackPool(&_callBackEnvironment, _pool);
             SetThreadpoolCallbackCleanupGroup(&_callBackEnvironment, _cleanupgroup, nullptr);

--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -73,7 +73,7 @@ class task_system {
                                    dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),
                                    new f_t(std::move(f)), [](void* f_) {
                                        auto f = static_cast<f_t*>(f_);
-                                       (*f)();
+                                       try { (*f)(); } catch (...) {}
                                        delete f;
                                    });
         }
@@ -102,7 +102,7 @@ struct default_executor_type {
         emscripten_async_call(
             [](void* f_) {
                 auto f = static_cast<f_t*>(f_);
-                (*f)();
+                try { (*f)(); } catch (...) {}
                 delete f;
             },
             new f_t(std::move(f)), 0);
@@ -122,7 +122,7 @@ struct default_executor_type {
                                                     pp::CompletionCallback(
                                                         [](void* f_, int32_t) {
                                                             auto f = static_cast<f_t*>(f_);
-                                                            (*f)();
+                                                            try { (*f)(); } catch (...) {}
                                                             delete f;
                                                         },
                                                         new f_t(std::move(f))),
@@ -175,7 +175,7 @@ class task_system {
                                            PVOID parameter,
                                            PTP_WORK /*Work*/) {
             std::unique_ptr<F> f(static_cast<F*>(parameter));
-            (*f)();
+            try { (*f)(); } catch (...) {}
         }
     };
     
@@ -265,7 +265,7 @@ class task_system {
                 }
                 if (!f && !_q[i].pop(f)) break;
                 
-                f();
+                try { f(); } catch (...) {}
             }
         }
         


### PR DESCRIPTION
- View changes while ignoring white space
- To fix issue #197 for the portable version
  we retain the executor until every block has finished
- I am sure this technique can be used for the other versions
   of the executors if we agree this approach is desirable