### PR TITLE
Executor fixes

### DIFF
--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -63,7 +63,9 @@ private:
         dispatch_group_t _group = dispatch_group_create();
         ~group() {
             dispatch_group_wait(_group, DISPATCH_TIME_FOREVER);
+#if !__has_feature(objc_arc)
             dispatch_release(_group);
+#endif
         }
     };
 

--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -140,7 +140,10 @@ public:
         if (_pool == nullptr) throw std::bad_alloc();
 
         _cleanupgroup = CreateThreadpoolCleanupGroup();
-        if (_pool == nullptr) throw std::bad_alloc();
+        if (_cleanupgroup == nullptr) {
+            CloseThreadpool(_pool);
+            throw std::bad_alloc();
+        }
 
         SetThreadpoolCallbackPool(&_callBackEnvironment, _pool);
         SetThreadpoolCallbackCleanupGroup(&_callBackEnvironment, _cleanupgroup, nullptr);


### PR DESCRIPTION
Fix Windows pool init
- Check the correct member for init
- If `CreateThreadpoolCleanupGroup()` fails then
  cleanup the allocated pool

Allow compile with ARC enabled on Mac

Note: If someone uses the executor directly and it throws then
the program will terminate with an uncaught exception. Is this
something we want to protect against?