### PR TITLE
allow for mutable lambdas in future::then

### DIFF
--- a/stlab/concurrency/future.hpp
+++ b/stlab/concurrency/future.hpp
@@ -262,7 +262,7 @@ struct shared_base<T, enable_if_copyable<T>> : std::enable_shared_from_this<shar
 
     template <typename S, typename F>
     auto then(S s, F f) {
-        return recover(std::move(s), [_f = std::move(f)](const auto& x){
+        return recover(std::move(s), [_f = std::move(f)](const auto& x) mutable {
             return _f(x._p->get_ready());
         });
     }
@@ -273,7 +273,7 @@ struct shared_base<T, enable_if_copyable<T>> : std::enable_shared_from_this<shar
     template <typename S, typename F>
     auto recover(S s, F f) {
         auto p = package<std::result_of_t<F(future<T>)>()>(s,
-            [_f = std::move(f), _p = future<T>(this->shared_from_this())] {
+            [_f = std::move(f), _p = future<T>(this->shared_from_this())] () mutable {
                 return _f(_p);
             });
 


### PR DESCRIPTION
These changes are necessary to get the following example code to compile:

```cpp
#include "stlab/concurrency/future.hpp"
#include "stlab/concurrency/utility.hpp"
#include "stlab/concurrency/default_executor.hpp"

int main(int argc, const char * argv[]) {
    int captured = 1;
    stlab::future<int> foo = stlab::make_ready_future(10, stlab::default_executor);
    foo.then(stlab::default_executor, [c = captured](auto i) mutable {
        return ++c + i;
    });
}
```

In general, I'd like `then` to support mutable lambdas. Here's a snippet from a more "real-world" example. `get_endpoints` is a `stlab::future<some_url_object>` which must complete before I execute some REST API request against one of the URLs in `some_url_object`.

```cpp
        return get_endpoints.then( stlab::default_executor,
            [s = this->my_rest_api] (endpoints urls) mutable {
                return s.set_url(std::move(urls.my_url))
                        .perform()
                        .then( [](auto r) { return interpret(std::move(r)); });
        });
```
