### PR TITLE
Remove check of Boost::unit_test_framework target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,12 +123,6 @@ if ( stlab.testing OR stlab.boost_variant OR stlab.boost_optional )
     endif()
   endif()
 
-
-  if(NOT TARGET Boost::unit_test_framework)
-    message(FATAL_ERROR "Could not find Boost unit test framework.")
-  endif()
-  
-
   string( APPEND either_generator
     "$<OR:$<BOOL:${stlab.boost_optional}>,"
          "$<BOOL:${stlab.boost_variant}>>" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,8 +148,6 @@ if ( stlab.testing OR stlab.boost_variant OR stlab.boost_optional )
 endif()
 
 list( APPEND CMAKE_MODULE_PATH "${stlab_SOURCE_DIR}/cmake" )
-include( stlab/coroutines )
-target_link_libraries( stlab INTERFACE stlab::coroutines )
 
 if ( stlab.testing )
   include( stlab/development )
@@ -203,7 +201,7 @@ write_basic_package_version_file(
 # generate a CMake configuration file for consumption by CMake's `find_package`
 # intrinsic
 #
-install( TARGETS stlab coroutines EXPORT stlabTargets )
+install( TARGETS stlab EXPORT stlabTargets )
 
 #
 # Non-testing header files (preserving relative paths) are installed to the


### PR DESCRIPTION
It is REQUIRED if not using conan, so will fail if can't find.
And it is manually created if using conan.

Currently cmake configuration fails if there are no
boost unit test framework, even if stlab.testing is OFF