### PR TITLE
Fix boost variant and optional implying test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,8 +123,7 @@ if ( stlab.testing OR stlab.boost_variant OR stlab.boost_optional )
     endif()
   endif()
 
-
-  if(NOT TARGET Boost::unit_test_framework)
+  if (stlab.testing AND NOT TARGET Boost::unit_test_framework)
     message(FATAL_ERROR "Could not find Boost unit test framework.")
   endif()
   


### PR DESCRIPTION
If either `stlab.boost_variant` or `stlab.boost_optional` is on but boost test is not available, the build fails even if `BUILD_TESTING` is turned off.

Turned up in [this](https://github.com/Microsoft/vcpkg/pull/6209) PR for vcpkg