### PR TITLE
Added channel router

### DIFF
--- a/stlab/concurrency/router.hpp
+++ b/stlab/concurrency/router.hpp
@@ -62,13 +62,13 @@ private:
     using mutable_static_routes = std::array<std::pair<K, channel_t>, N>;
 
     template<std::size_t N, std::size_t... Is>
-    static static_routes<N> make_static_routes(const mutable_static_routes<N>& mutable_routes, std::index_sequence<Is...>) {
-        return {{ {std::get<0>(mutable_routes[Is]), std::get<1>(mutable_routes[Is])}... }};
+    static static_routes<N> make_static_routes(mutable_static_routes<N> mutable_routes, std::index_sequence<Is...>) {
+        return {{ {std::move(std::get<0>(mutable_routes[Is])), std::move(std::get<1>(mutable_routes[Is]))}... }};
     }
 
     template<std::size_t N, std::size_t... Is>
-    static static_routes<N> make_static_routes(const mutable_static_routes<N>& mutable_routes) {
-        return make_static_routes(mutable_routes, std::make_index_sequence<N>());
+    static static_routes<N> make_static_routes(mutable_static_routes<N> mutable_routes) {
+        return make_static_routes(std::move(mutable_routes), std::make_index_sequence<N>());
     }
 
     template<std::size_t N, class E>
@@ -77,7 +77,7 @@ private:
         std::transform(std::begin(route_keys), std::end(route_keys), std::begin(result), [](auto route_key) -> route_pair {
             return {std::get<0>(route_key), channel<T>(std::get<1>(route_key))};
         });
-        return make_static_routes(result);
+        return make_static_routes(std::move(result));
     }
 
     struct concept_t {

--- a/stlab/concurrency/router.hpp
+++ b/stlab/concurrency/router.hpp
@@ -71,11 +71,11 @@ private:
         }
 
         receiver<T> get_route(const K& key) const override {
-            auto find_it = std::find_if(begin(_routes), std::end(_routes), [&](const route_pair& pair){
-                return pair.first == key;
+            auto find_it = std::lower_bound(std::begin(_routes), std::end(_routes), key, [](const route_pair& a, const K& k){
+                return a.first < k;
             });
-            if (find_it != std::end(_routes)) return find_it->second.second;
-            throw std::runtime_error("no such route");
+            if (find_it == std::end(_routes) || find_it->first != key) throw std::runtime_error("no such route");
+            return find_it->second.second;
         }
 
         void route(T t) override {

--- a/stlab/concurrency/router.hpp
+++ b/stlab/concurrency/router.hpp
@@ -28,8 +28,8 @@ inline namespace v1 {
 
 template <class T, class K>
 class router {
-    using channel_pair = std::pair<sender<T>, receiver<T>>;
-    using route_pair = std::pair<K, channel_pair>;
+    using channel_t = std::pair<sender<T>, receiver<T>>;
+    using route_pair = std::pair<K, channel_t>;
     using routes = std::vector<route_pair>;
 
 public:
@@ -118,7 +118,7 @@ private:
         E _executor;
         F _router_func;
         routes _routes;
-        channel_pair _sender_receiver;
+        channel_t _sender_receiver;
     };
 
     std::shared_ptr<concept_t> _self;

--- a/stlab/concurrency/router.hpp
+++ b/stlab/concurrency/router.hpp
@@ -82,11 +82,11 @@ private:
             if (std::empty(_routes)) return _default_route.first(std::move(t));
             const auto& keys = _router_func(t);
             if (std::empty(keys)) return _default_route.first(std::move(t));
-            route_keys(keys, std::move(t));
+            route(keys, std::move(t));
         }
 
         template<class C, typename std::enable_if_t<std::is_same<typename C::value_type, std::pair<K, bool>>::value, int> = 0>
-        void route_keys(const C& keys, T t) {
+        void route(const C& keys, T t) {
             bool did_route = false;
             auto find_it = std::begin(_routes);
             for (const auto& key : keys) {
@@ -103,7 +103,7 @@ private:
         }
 
         template<class C, typename std::enable_if_t<std::is_same<typename C::value_type, K>::value, int> = 0>
-        void route_keys(const C& keys, T t) {
+        void route(const C& keys, T t) {
             auto find_it = std::begin(_routes);
             for (const auto& key : keys) {
                 find_it = std::lower_bound(find_it, std::end(_routes), key, [](const route_pair& a, const K& k){

--- a/stlab/concurrency/router.hpp
+++ b/stlab/concurrency/router.hpp
@@ -1,0 +1,137 @@
+/*
+    Copyright 2015 Adobe
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/**************************************************************************************************/
+
+#ifndef STLAB_CONCURRENCY_ROUTER_HPP
+#define STLAB_CONCURRENCY_ROUTER_HPP
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <stlab/concurrency/channel.hpp>
+
+/**************************************************************************************************/
+
+namespace stlab {
+
+/**************************************************************************************************/
+
+inline namespace v1 {
+
+/**************************************************************************************************/
+
+template <class T, class K>
+class router {
+    using channel_pair = std::pair<stlab::sender<T>, stlab::receiver<T>>;
+    using route_pair = std::pair<K, channel_pair>;
+    using routes = std::vector<route_pair>;
+
+public:
+    template <class E, class F>
+    router(E executor, F router_func) : _self{std::make_shared<model<E, F>>(std::move(executor), std::move(router_func))} {}
+
+    void set_ready() { _self->set_ready(); }
+    stlab::receiver<T> get_route(K key) { return _self->get_route(std::move(key)); }
+    stlab::receiver<T> get_default_route() { return _self->get_default_route(); }
+    void operator()(T t) { _self->route(std::move(t)); }
+
+private:
+    struct concept_t {
+        virtual stlab::receiver<T> get_route(K key) = 0;
+        virtual stlab::receiver<T> get_default_route() = 0;
+        virtual void set_ready() = 0;
+        virtual void route(T t) = 0;
+        virtual ~concept_t() = default;
+    };
+
+    template <class E, class F>
+    struct model : concept_t {
+        model(E executor, F router_func)
+        : _executor{std::move(executor)}
+        , _router_func{std::move(router_func)}
+        , _sender_receiver{stlab::channel<T>(_executor)}
+        {}
+
+        void set_ready() override {
+            std::sort(std::begin(_routes), std::end(_routes), [](const route_pair& a, const route_pair& b){
+                return a.first < b.first;
+            });
+            for (auto& pair : _routes)
+                pair.second.second.set_ready();
+            _sender_receiver.second.set_ready();
+        }
+
+        stlab::receiver<T> get_default_route() override { return _sender_receiver.second; }
+
+        stlab::receiver<T> get_route(K key) override {
+            auto find_it = std::find_if(begin(_routes), std::end(_routes), [&](const route_pair& pair){
+                return pair.first == key;
+            });
+            if (find_it != std::end(_routes)) return find_it->second.second;
+            _routes.push_back(std::make_pair(std::move(key), stlab::channel<T>(_executor)));
+            return _routes.back().second.second;
+        }
+
+        template<class C, typename std::enable_if_t<std::is_same<typename C::value_type, std::pair<K, bool>>::value, int> = 0>
+        void route_keys(const C& key_set, T t) {
+            bool did_route = false;
+            auto find_it = std::begin(_routes);
+            for (const auto& key : key_set) {
+                if (!key.second) continue;
+                find_it = std::lower_bound(find_it, std::end(_routes), key, [](const route_pair& a, const std::pair<K, bool>& k){
+                    return a.first < k.first;
+                });
+                if (find_it == std::end(_routes)) break;
+                if (find_it->first != key.first) continue;
+                find_it->second.first(t);
+                did_route = true;
+            }
+            if (!did_route) return _sender_receiver.first(std::move(t));
+        }
+
+        template<class C, typename std::enable_if_t<std::is_same<typename C::value_type, K>::value, int> = 0>
+        void route_keys(const C& key_set, T t) {
+            auto find_it = std::begin(_routes);
+            for (const auto& key : key_set) {
+                find_it = std::lower_bound(find_it, std::end(_routes), key, [](const route_pair& a, const K& k){
+                    return a.first < k;
+                });
+                if (find_it == std::end(_routes)) return;
+                if (find_it->first != key) continue;
+                find_it->second.first(t);
+            }
+        }
+
+        void route(T t) override {
+            if (std::empty(_routes)) return _sender_receiver.first(std::move(t));
+            const auto& key_set = _router_func(t);
+            if (std::empty(key_set)) return _sender_receiver.first(std::move(t));
+            route_keys(key_set, std::move(t)); 
+        }
+
+        E _executor;
+        F _router_func;
+        routes _routes;
+        channel_pair _sender_receiver;
+    };
+
+    std::shared_ptr<concept_t> _self;
+};
+
+/**************************************************************************************************/
+
+} // namespace v1
+
+/**************************************************************************************************/
+
+} // namespace stlab
+
+/**************************************************************************************************/
+
+#endif

--- a/stlab/concurrency/router.hpp
+++ b/stlab/concurrency/router.hpp
@@ -34,7 +34,7 @@ class router {
 
 public:
     template <class E, class F>
-    router(E executor, F router_func) : _self{std::make_shared<model<E, F>>(std::move(executor), std::move(router_func))} {}
+    router(E executor, F router_func) : _self{std::make_unique<model<E, F>>(std::move(executor), std::move(router_func))} {}
 
     void set_ready() { _self->set_ready(); }
     receiver<T> get_route(K key) { return _self->get_route(std::move(key)); }
@@ -121,7 +121,7 @@ private:
         channel_t _default_route;
     };
 
-    std::shared_ptr<concept_t> _self;
+    std::unique_ptr<concept_t> _self;
 };
 
 /**************************************************************************************************/

--- a/stlab/concurrency/router.hpp
+++ b/stlab/concurrency/router.hpp
@@ -54,7 +54,7 @@ public:
         _router_function(std::move(router_function)), _routes{
                                                           std::make_pair(route_pairs.first,
                                                                          route_pairs.second)...} {
-        assert(std::is_sorted(_routes.cbegin(), _routes.cend(),
+        assert(std::is_sorted(std::cbegin(_routes), std::cend(_routes),
                               [](const auto& x, const auto& y) { return x.first < y.first; }));
         set_ready();
     }
@@ -66,10 +66,10 @@ public:
     }
 
     stlab::optional<receiver<T>> route(const K& key) const {
-        auto find_it = std::lower_bound(_routes.cbegin(), _routes.cend(), key,
+        auto find_it = std::lower_bound(std::cbegin(_routes), std::cend(_routes), key,
                                         [](const auto& p, const auto& k) { return p.first < k; });
 
-        if (find_it == _routes.end() || find_it->first != key) return stlab::nullopt;
+        if (find_it == std::cend(_routes) || find_it->first != key) return stlab::nullopt;
         return find_it->second.second;
     }
 
@@ -79,10 +79,10 @@ public:
 
         channel_t<T> ch = channel<T>(std::move(executor));
         auto result = ch.second;
-        auto insert_it = std::lower_bound(_routes.begin(), _routes.end(), key,
+        auto insert_it = std::lower_bound(std::cbegin(_routes), std::cend(_routes), key,
                                           [](const auto& p, const auto& k) { return p.first < k; });
 
-        assert(insert_it == _routes.end() || insert_it->first != key);
+        assert(insert_it == std::cend(_routes) || insert_it->first != key);
 
         _routes.insert(insert_it, std::make_pair(std::move(key), std::move(ch)));
 
@@ -97,12 +97,12 @@ public:
             auto _this = _weak_this.lock();
             if (!_this) return;
             auto keys = _this->_router_function(_arg);
-            auto find_it = std::begin(_this->_routes);
+            auto find_it = std::cbegin(_this->_routes);
             for (const auto& key : keys) {
                 find_it =
-                    std::lower_bound(find_it, std::end(_this->_routes), key,
+                    std::lower_bound(find_it, std::cend(_this->_routes), key,
                                      [](const auto& p, const auto& k) { return p.first < k; });
-                if (find_it == std::end(_this->_routes)) return;
+                if (find_it == std::cend(_this->_routes)) return;
                 if (find_it->first != key) continue;
                 find_it->second.first(_arg);
             }

--- a/stlab/concurrency/router.hpp
+++ b/stlab/concurrency/router.hpp
@@ -78,6 +78,13 @@ private:
             return _routes.back().second.second;
         }
 
+        void route(T t) override {
+            if (std::empty(_routes)) return _default_route.first(std::move(t));
+            const auto& keys = _router_func(t);
+            if (std::empty(keys)) return _default_route.first(std::move(t));
+            route_keys(keys, std::move(t));
+        }
+
         template<class C, typename std::enable_if_t<std::is_same<typename C::value_type, std::pair<K, bool>>::value, int> = 0>
         void route_keys(const C& keys, T t) {
             bool did_route = false;
@@ -106,13 +113,6 @@ private:
                 if (find_it->first != key) continue;
                 find_it->second.first(t);
             }
-        }
-
-        void route(T t) override {
-            if (std::empty(_routes)) return _default_route.first(std::move(t));
-            const auto& keys = _router_func(t);
-            if (std::empty(keys)) return _default_route.first(std::move(t));
-            route_keys(keys, std::move(t)); 
         }
 
         E _executor;

--- a/stlab/concurrency/router.hpp
+++ b/stlab/concurrency/router.hpp
@@ -79,10 +79,10 @@ private:
         }
 
         template<class C, typename std::enable_if_t<std::is_same<typename C::value_type, std::pair<K, bool>>::value, int> = 0>
-        void route_keys(const C& key_set, T t) {
+        void route_keys(const C& keys, T t) {
             bool did_route = false;
             auto find_it = std::begin(_routes);
-            for (const auto& key : key_set) {
+            for (const auto& key : keys) {
                 if (!key.second) continue;
                 find_it = std::lower_bound(find_it, std::end(_routes), key, [](const route_pair& a, const std::pair<K, bool>& k){
                     return a.first < k.first;
@@ -96,9 +96,9 @@ private:
         }
 
         template<class C, typename std::enable_if_t<std::is_same<typename C::value_type, K>::value, int> = 0>
-        void route_keys(const C& key_set, T t) {
+        void route_keys(const C& keys, T t) {
             auto find_it = std::begin(_routes);
-            for (const auto& key : key_set) {
+            for (const auto& key : keys) {
                 find_it = std::lower_bound(find_it, std::end(_routes), key, [](const route_pair& a, const K& k){
                     return a.first < k;
                 });
@@ -110,9 +110,9 @@ private:
 
         void route(T t) override {
             if (std::empty(_routes)) return _default_route.first(std::move(t));
-            const auto& key_set = _router_func(t);
-            if (std::empty(key_set)) return _default_route.first(std::move(t));
-            route_keys(key_set, std::move(t)); 
+            const auto& keys = _router_func(t);
+            if (std::empty(keys)) return _default_route.first(std::move(t));
+            route_keys(keys, std::move(t)); 
         }
 
         E _executor;

--- a/stlab/concurrency/router.hpp
+++ b/stlab/concurrency/router.hpp
@@ -77,14 +77,14 @@ public:
     receiver<T> add_route(K key, Ex executor) {
         assert(!_ready);
 
-        channel_t<T> ch = channel<T>(executor);
+        channel_t<T> ch = channel<T>(std::move(executor));
         auto result = ch.second;
         auto insert_it = std::lower_bound(_routes.begin(), _routes.end(), key,
                                           [](const auto& p, const auto& k) { return p.first < k; });
 
         assert(insert_it == _routes.end() || insert_it->first != key);
 
-        _routes.insert(insert_it, std::make_pair(key, std::move(ch)));
+        _routes.insert(insert_it, std::make_pair(std::move(key), std::move(ch)));
 
         return result;
     }

--- a/stlab/concurrency/router.hpp
+++ b/stlab/concurrency/router.hpp
@@ -1,7 +1,7 @@
 /*
-    Copyright 2015 Adobe
-    Distributed under the Boost Software License, Version 1.0.
-    (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+Copyright 2015 Adobe
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 */
 
 /**************************************************************************************************/
@@ -10,10 +10,8 @@
 #define STLAB_CONCURRENCY_ROUTER_HPP
 
 #include <algorithm>
-#include <memory>
 #include <utility>
 #include <vector>
-#include <stdexcept>
 
 #include <stlab/concurrency/channel.hpp>
 
@@ -24,127 +22,161 @@ namespace stlab {
 /**************************************************************************************************/
 
 inline namespace v1 {
-
 /**************************************************************************************************/
 
-template <class T, class K>
-class router {
-    using channel_t = std::pair<sender<T>, receiver<T>>;
-    using route_pair = std::pair<const K, channel_t>;
-    using routes = std::vector<route_pair>;
+template <typename T>
+using channel_t = std::pair<sender<T>, receiver<T>>;
 
-    template<std::size_t N>
-    using static_routes = std::array<route_pair, N>;
+namespace detail {
+
+template <typename T, typename K, typename E, typename F>
+class shared_router : public std::enable_shared_from_this<shared_router<T, K, E, F>> {
+    using route_pair_t = std::pair<K, channel_t<T>>;
+    E _executor; // of the router function
+    F _router_function;
+    std::vector<route_pair_t> _routes;
+    bool _ready = false;
 
 public:
-    template <class I, class F>
-    router(const std::pair<I, I>& key_range, F router_func) : _self{std::make_unique<model<routes, F>>(make_routes(key_range), std::move(router_func))} {}
+    shared_router() = default;
+    ~shared_router() = default;
+    shared_router(shared_router&&) = default;
+    shared_router(const shared_router&) = default;
+    shared_router& operator=(shared_router&&) = default;
+    shared_router& operator=(const shared_router&) = default;
 
-    template <std::size_t N, class E, class F>
-    router(const std::array<std::pair<K, E>, N>& route_keys, F router_func) : _self{std::make_unique<model<static_routes<N>, F>>(make_routes(route_keys), std::move(router_func))} {}
+    shared_router(E executor, F router_function) :
+        _executor{executor}, _router_function(std::move(router_function)) {}
 
-    void set_ready() { _self->set_ready(); }
-    receiver<T> get_route(const K& key) const { return _self->get_route(key); }
-    void operator()(T t) { _self->route(std::move(t)); }
+    template <typename... U>
+    shared_router(E executor, F router_function, std::pair<K, channel_t<U>>... route_pairs) :
+        _executor{std::move(executor)},
+        _router_function(std::move(router_function)), _routes{
+                                                          std::make_pair(route_pairs.first,
+                                                                         route_pairs.second)...} {
+        assert(std::is_sorted(_routes.cbegin(), _routes.cend(),
+                              [](const auto& x, const auto& y) { return x.first < y.first; }));
+        set_ready();
+    }
 
-private:
-    template<class I>
-    static routes make_routes(const std::pair<I, I>& range) {
-        routes result;
-        std::transform(range.first, range.second, std::back_inserter(result), [](auto route_key) -> route_pair {
-            return {std::get<0>(route_key), channel<T>(std::get<1>(route_key))};
-        });
-        if (std::empty(result)) throw std::runtime_error("no routes provided");
+    void set_ready() {
+        for (auto& route : _routes)
+            route.second.second.set_ready();
+        _ready = true;
+    }
+
+    stlab::optional<receiver<T>> route(K key) const {
+        stlab::optional<receiver<T>> result;
+
+        auto find_it = std::lower_bound(_routes.begin(), _routes.end(), key,
+                                        [](const auto& p, const auto& k) { return p.first < k; });
+
+        if (find_it == _routes.end() || find_it->first != key) return result;
+        result = find_it->second.second;
+
         return result;
     }
 
-    template<std::size_t N>
-    using mutable_static_routes = std::array<std::pair<K, channel_t>, N>;
+    template <typename Ex>
+    receiver<T> add_route(K key, Ex executor) {
+        assert(!_ready);
 
-    template<std::size_t N, std::size_t... Is>
-    static static_routes<N> make_static_routes(mutable_static_routes<N> mutable_routes, std::index_sequence<Is...>) {
-        return {{ {std::move(std::get<0>(mutable_routes[Is])), std::move(std::get<1>(mutable_routes[Is]))}... }};
+        channel_t<T> ch = channel<T>(executor);
+        auto result = ch.second;
+        auto insert_it = std::lower_bound(_routes.begin(), _routes.end(), key,
+                                          [](const auto& p, const auto& k) { return p.first < k; });
+
+        assert(insert_it == _routes.end() || insert_it->first != key);
+
+        _routes.insert(insert_it, std::make_pair(key, std::move(ch)));
+
+        return result;
     }
 
-    template<std::size_t N, std::size_t... Is>
-    static static_routes<N> make_static_routes(mutable_static_routes<N> mutable_routes) {
-        return make_static_routes(std::move(mutable_routes), std::make_index_sequence<N>());
-    }
+    receiver<T> add_route(K key) { return add_route(std::move(key), _executor); }
 
-    template<std::size_t N, class E>
-    static static_routes<N> make_routes(const std::array<std::pair<K, E>, N>& route_keys) {
-        mutable_static_routes<N> result;
-        std::transform(std::begin(route_keys), std::end(route_keys), std::begin(result), [](auto route_key) -> route_pair {
-            return {std::get<0>(route_key), channel<T>(std::get<1>(route_key))};
-        });
-        return make_static_routes(std::move(result));
-    }
-
-    struct concept_t {
-        virtual receiver<T> get_route(const K& key) const = 0;
-        virtual void set_ready() = 0;
-        virtual void route(T t) = 0;
-        virtual ~concept_t() = default;
-    };
-
-    template <class R, class F>
-    struct model : concept_t {
-        model(R routes, F router_func)
-        : _routes{std::move(routes)}
-        , _router_func{std::move(router_func)}
-        {}
-
-        void set_ready() override {
-            for (auto& pair : _routes) pair.second.second.set_ready();
-        }
-
-        receiver<T> get_route(const K& key) const override {
-            auto find_it = std::lower_bound(std::begin(_routes), std::end(_routes), key, [](const route_pair& a, const K& k){
-                return a.first < k;
-            });
-            if (find_it == std::end(_routes) || find_it->first != key) throw std::runtime_error("no such route");
-            return find_it->second.second;
-        }
-
-        void route(T t) override {
-            const auto& keys = _router_func(t);
-            if (std::empty(keys)) return;
-            route(keys, std::move(t));
-        }
-
-        template<class C, typename std::enable_if_t<std::is_same<typename C::value_type, std::pair<K, bool>>::value, int> = 0>
-        void route(const C& keys, T t) {
-            auto find_it = std::begin(_routes);
+    void operator()(T arg) {
+        assert(_ready);
+        _executor([_weak_this = make_weak_ptr(this->shared_from_this()), _arg = std::move(arg)] {
+            auto _this = _weak_this.lock();
+            if (!_this) return;
+            auto keys = _this->_router_function(_arg);
+            auto find_it = std::begin(_this->_routes);
             for (const auto& key : keys) {
-                if (!key.second) continue;
-                find_it = std::lower_bound(find_it, std::end(_routes), key, [](const route_pair& a, const std::pair<K, bool>& k){
-                    return a.first < k.first;
-                });
-                if (find_it == std::end(_routes)) break;
-                if (find_it->first != key.first) continue;
-                find_it->second.first(t);
-            }
-        }
-
-        template<class C, typename std::enable_if_t<std::is_same<typename C::value_type, K>::value, int> = 0>
-        void route(const C& keys, T t) {
-            auto find_it = std::begin(_routes);
-            for (const auto& key : keys) {
-                find_it = std::lower_bound(find_it, std::end(_routes), key, [](const route_pair& a, const K& k){
-                    return a.first < k;
-                });
-                if (find_it == std::end(_routes)) return;
+                find_it =
+                    std::lower_bound(find_it, std::end(_this->_routes), key,
+                                     [](const auto& p, const auto& k) { return p.first < k; });
+                if (find_it == std::end(_this->_routes)) return;
                 if (find_it->first != key) continue;
-                find_it->second.first(t);
+                find_it->second.first(_arg);
             }
-        }
-
-        F _router_func;
-        R _routes;
-    };
-
-    std::unique_ptr<concept_t> _self;
+        });
+    }
 };
+
+} // namespace detail
+
+/**************************************************************************************************/
+
+template <typename T, typename K, typename E, typename F>
+class router {
+    using ptr_t = std::shared_ptr<detail::shared_router<T, K, E, F>>;
+    ptr_t _p;
+
+public:
+    router() = default;
+    ~router() = default;
+
+    void swap(router& x) noexcept { std::swap(_p, x._p); }
+
+    inline friend void swap(router& x, router& y) { x.swap(y); }
+    inline friend bool operator==(const router& x, const router& y) {
+        return (x._p && y._p && *x._p == *y._p) || (!x._p && !y._p);
+    }
+    inline friend bool operator!=(const router& x, const router& y) { return !(x == y); }
+
+    bool valid() const { return static_cast<bool>(_p); }
+
+    router(router&&) = default;
+    router& operator=(router&&) = default;
+
+    router(const router& x) : _p(std::make_shared<detail::shared_router<T, K, E, F>>(*x._p)) {}
+
+    router& operator=(const router& x) {
+        auto tmp = x;
+        *this = std::move(tmp);
+        return *this;
+    }
+
+    router(E executor, F router_function) :
+        _p(std::make_shared<detail::shared_router<T, K, E, F>>(std::move(executor),
+                                                               std::move(router_function))) {}
+
+    template <typename... U>
+    router(E executor, F router_function, std::pair<K, channel_t<U>>... route_pairs) :
+        _p(std::make_shared<detail::shared_router<T, K, E, F>>(
+            std::move(executor),
+            std::move(router_function),
+            std::make_pair(route_pairs.first, route_pairs.second)...)) {}
+
+    void set_ready() { _p->set_ready(); }
+
+    stlab::optional<receiver<T>> route(K key) const { return _p->route(std::move(key)); }
+
+    template <typename Ex>
+    receiver<T> add_route(K key, Ex executor) {
+        return _p->add_route(std::move(key), std::move(executor));
+    }
+
+    receiver<T> add_route(K key) { return _p->add_route(std::move(key)); }
+
+    void operator()(T arg) { _p->operator()(std::move(arg)); }
+};
+
+template <typename T, typename K, typename E, typename F>
+auto make_router(E executor, F router_function) {
+    return router<T, K, E, F>(std::move(executor), std::move(router_function));
+}
 
 /**************************************************************************************************/
 


### PR DESCRIPTION
- This router can conditionally send values down
  different paths in the graph.

```c++
/*
    Copyright 2015 Adobe
    Distributed under the Boost Software License, Version 1.0.
    (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
*/

/**************************************************************************************************/

#include <stlab/concurrency/channel.hpp>
#include <stlab/concurrency/default_executor.hpp>
#include <stlab/concurrency/router.hpp>
#include <stlab/concurrency/serial_queue.hpp>

#include <iostream>
#include <string>
#include <thread>

using namespace std;
using namespace std::placeholders;
using namespace stlab;

void dynamic_test() {
    auto [send, receive] = channel<std::string>(default_executor);

    auto sq = serial_queue_t{default_executor};

    auto router = stlab::make_router<std::string, std::string>(sq.executor(), [](const std::string& t) {
        std::vector<std::string> result;
        if (t.find("hello") != std::string::npos) result.push_back("contains hello");
        if (t.find("hello") != std::string::npos) result.push_back("contains hello");
        if (t.find("world") != std::string::npos) result.push_back("contains world");
        if (t == "hello world") result.push_back("hello world");
        if (result.empty()) result.push_back("default");
        return result;
    });

    std::atomic_int done{9};

    auto default_case = router.add_route("default", default_executor) |
                        [](std::string t) -> std::string { return t + ": default case\n"; };
    
    auto default_case_again = *router.route("default") |
                        [](std::string t) -> std::string { return t + ": default case again\n"; };

    auto hello_world = router.add_route("hello world", default_executor) |
                       [](std::string t) -> std::string { return t + ": is hello world\n"; };

    auto hello = router.add_route("contains hello", default_executor) |
                 [](std::string t) -> std::string { return t + ": contains hello\n"; };

    auto world = router.add_route("contains world", default_executor) |
                 [](std::string t) -> std::string { return t + ": contains world\n"; };

    router.set_ready();
    auto hold = receive | std::ref(router);

    auto all_cases = stlab::merge_channel<unordered_t>(
        stlab::default_executor,
        [& _done = done](std::string message) {
            std::cout << message;
            --_done;
        },
        std::move(default_case), std::move(default_case_again), std::move(hello), std::move(world), std::move(hello_world));

    // It is necessary to mark the receiver side as ready, when all connections are
    // established
    receive.set_ready();
    hold.set_ready();

    send("bob");
    send("hello");
    send("world");
    send("hello world");

    // Waiting just for illustrational purpose
    while (done.load() != 0) {
        std::this_thread::sleep_for(chrono::milliseconds(1));
    }
}

void static_test() {
    auto [send, receive] = channel<std::string>(default_executor);

    auto sq = serial_queue_t{default_executor};

    auto channel_contains_hello = std::make_pair("contains hello"s, channel<std::string>(default_executor));
    auto channel_contains_world = std::make_pair("contains world"s, channel<std::string>(default_executor));
    auto channel_default = std::make_pair("default"s, channel<std::string>(default_executor));
    auto channel_hello_world = std::make_pair("hello world"s, channel<std::string>(default_executor));

    auto default_case = channel_default.second.second |
                        [](std::string t) -> std::string { return t + ": default case\n"; };
    
    auto default_case_again = channel_default.second.second |
                        [](std::string t) -> std::string { return t + ": default case again\n"; };

    auto hello_world = channel_hello_world.second.second |
                       [](std::string t) -> std::string { return t + ": is hello world\n"; };

    auto hello = channel_contains_hello.second.second |
                 [](std::string t) -> std::string { return t + ": contains hello\n"; };

    auto world = channel_contains_world.second.second |
                 [](std::string t) -> std::string { return t + ": contains world\n"; };

    std::atomic_int done{9};

    auto all_cases = stlab::merge_channel<unordered_t>(
        stlab::default_executor,
        [& _done = done](std::string message) {
            std::cout << message;
            --_done;
        },
        std::move(default_case), std::move(default_case_again), std::move(hello), std::move(world), std::move(hello_world));

    auto router = stlab::make_router<std::string, std::string>(sq.executor(), [](const std::string& t) {
        std::vector<std::string> result;
        if (t.find("hello") != std::string::npos) result.push_back("contains hello");
        if (t.find("hello") != std::string::npos) result.push_back("contains hello");
        if (t.find("world") != std::string::npos) result.push_back("contains world");
        if (t == "hello world") result.push_back("hello world");
        if (result.empty()) result.push_back("default");
        return result;
    }
    , std::move(channel_contains_hello)
    , std::move(channel_contains_world)
    , std::move(channel_default)
    , std::move(channel_hello_world));

    auto hold = receive | std::ref(router);

    // It is necessary to mark the receiver side as ready, when all connections are
    // established
    receive.set_ready();
    hold.set_ready();

    send("bob");
    send("hello");
    send("world");
    send("hello world");

    // Waiting just for illustrational purpose
    while (done.load() != 0) {
        std::this_thread::sleep_for(chrono::milliseconds(1));
    }
}

int main() {
    std::cout << "dynamic_test" << std::endl;
    dynamic_test();
    std::cout << "static_test" << std::endl;
    static_test();
    return 0;
}
```