### PR TITLE
[CI] Add MSVC 2019 to the build matrix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,9 +5,6 @@
 
 shallow_clone: true
 
-image:
-  - Visual Studio 2017
-
 build:
   verbosity: detailed
 
@@ -31,19 +28,30 @@ install:
   ############################################################################
   # Install a recent CMake
   ############################################################################
-  # - set CMAKE_URL="https://cmake.org/files/v3.8/cmake-3.8.0-win64-x64.zip"
+  # - set CMAKE_URL="https://cmake.org/files/v3.14/cmake-3.14.4-win32-x86.zip"
   # - appveyor DownloadFile %CMAKE_URL% -FileName cmake.zip
   # - 7z x cmake.zip -oC:\projects\deps > nul
   # - move C:\projects\deps\cmake-* C:\projects\deps\cmake # Move to a version-agnostic directory
   # - set PATH=C:\projects\deps\cmake\bin;%PATH%
   - cmake --version
 
+environment:
+  matrix:
+    - FLAVOR: Visual Studio 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CMAKE_TOOLSET: Visual Studio 15 2017 Win64
+      BOOST_ROOT: C:\Libraries\boost_1_69_0
+
+    - FLAVOR: Visual Studio 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      CMAKE_TOOLSET: Visual Studio 16 2019
+      BOOST_ROOT: C:\Libraries\boost_1_71_0
+
 build_script:
   - cd C:\projects\libraries
   - IF EXIST build RMDIR /S /Q build
   - MKDIR build
   - cd build
-  - cmake -G "Visual Studio 15 2017 Win64" -D BOOST_ROOT=C:/Libraries/boost_1_69_0 -D CMAKE_BUILD_TYPE=debug -D Boost_USE_STATIC_LIBS=ON ..
+  - cmake -G "%CMAKE_TOOLSET%" -D BOOST_ROOT="%BOOST_ROOT%" -D Boost_USE_STATIC_LIBS=ON ..
   - cmake --build . --config Release
-  - ctest -C Release 
-  
+  - ctest -C Release


### PR DESCRIPTION
For the records:
 - Visual Studio 2017 builds with Boost 1.69
 - Visual Studio 2019 builds with Boost 1.71