### PR TITLE
Fix: Single Portable System Timer

### DIFF
--- a/stlab/concurrency/system_timer.hpp
+++ b/stlab/concurrency/system_timer.hpp
@@ -260,6 +260,11 @@ public:
 
 struct system_timer_type {
     using result_type = void;
+    
+    static system_timer& get_system_timer() {
+        static system_timer only_system_timer;
+        return only_system_timer;
+    }
 
     [[deprecated("Use chrono::duration as parameter instead")]]
     void operator()(std::chrono::steady_clock::time_point when, task<void()> f) const {
@@ -268,8 +273,7 @@ struct system_timer_type {
 
     template <typename Rep, typename Per = std::ratio<1>>
     void operator()(std::chrono::duration<Rep, Per> duration, task<void()> f) const {
-        static system_timer only_system_timer;
-        only_system_timer(duration, std::move(f));
+        get_system_timer()(duration, std::move(f));
     }
 };
 


### PR DESCRIPTION
The local static is inside a templated function and therefore will create a system timer for every unique duration type passed.

This change ensures that only a single system timer is created when using the portable version.