### PR TITLE
Forest Algorithms

### DIFF
--- a/stlab/forest.hpp
+++ b/stlab/forest.hpp
@@ -756,6 +756,8 @@ public:
     using reverse_iterator = reverse_fullorder_iterator<iterator>;
     using const_reverse_iterator = reverse_fullorder_iterator<const_iterator>;
 
+    template <class U> struct rebind { using type = forest<U>; };
+
     /* qualification needed since: A name N used in a class S shall refer to the same declaration
        in its context and when re-evaluated in the completed scope of
        S. */

--- a/stlab/forest.hpp
+++ b/stlab/forest.hpp
@@ -65,7 +65,7 @@ constexpr auto is_leading(forest_edge e) {
 }
 
 template <class I> // I models a FullorderIterator
-auto is_leading(I i) {
+auto is_leading(const I& i) {
     return is_leading(i.edge());
 }
 
@@ -74,7 +74,7 @@ constexpr auto is_trailing(forest_edge e) {
 }
 
 template <class I> // I models a FullorderIterator
-auto is_trailing(I i) {
+auto is_trailing(const I& i) {
     return is_trailing(i.edge());
 }
 

--- a/stlab/forest.hpp
+++ b/stlab/forest.hpp
@@ -756,8 +756,6 @@ public:
     using reverse_iterator = reverse_fullorder_iterator<iterator>;
     using const_reverse_iterator = reverse_fullorder_iterator<const_iterator>;
 
-    template <class U> struct rebind { using type = forest<U>; };
-
     /* qualification needed since: A name N used in a class S shall refer to the same declaration
        in its context and when re-evaluated in the completed scope of
        S. */

--- a/stlab/forest_algorithms.hpp
+++ b/stlab/forest_algorithms.hpp
@@ -32,7 +32,7 @@ bool equal_shape(const Forest1& x, const Forest2& y) {
 /**************************************************************************************************/
 
 template <class Container>
-struct insert_iterator {
+struct transcribe_iterator {
     using iterator_category = std::output_iterator_tag;
     using value_type = void;
     using difference_type = void;
@@ -40,7 +40,7 @@ struct insert_iterator {
     using reference = void;
     using container_type = Container;
 
-    insert_iterator(Container& c, typename Container::iterator i) : _c{&c}, _i{std::move(i)} {}
+    transcribe_iterator(Container& c, typename Container::iterator i) : _c{&c}, _i{std::move(i)} {}
 
     constexpr auto& operator*() { return *this; }
     constexpr auto& operator++() {
@@ -53,12 +53,12 @@ struct insert_iterator {
         return result;
     }
 
-    constexpr insert_iterator<Container>& operator=(const typename Container::value_type& value) {
+    constexpr auto& operator=(const typename Container::value_type& value) {
         _i = _c->insert(_i, value);
         return *this;
     }
 
-    constexpr insert_iterator<Container>& operator=(typename Container::value_type&& value) {
+    constexpr auto& operator=(typename Container::value_type&& value) {
         _i = _c->insert(_i, std::move(value));
         return *this;
     }
@@ -71,8 +71,8 @@ private:
 };
 
 template <class Container>
-auto inserter(Container& c) {
-    return forests::insert_iterator(c, c.begin());
+auto transcriber(Container& c) {
+    return transcribe_iterator(c, c.begin());
 }
 
 /**************************************************************************************************/
@@ -127,7 +127,7 @@ template <class I, // I models ForwardIterator; I::value_type == stlab::optional
           class F> // F models Forest
 auto unflatten(I first, I last, F& f) {
     return forests::transcribe(
-        first, last, forests::inserter(f), [](const auto& x) { return *x; },
+        first, last, transcriber(f), [](const auto& x) { return *x; },
         [](const auto& p) { return *p; });
 }
 

--- a/stlab/forest_algorithms.hpp
+++ b/stlab/forest_algorithms.hpp
@@ -95,7 +95,7 @@ template <class Forest,
           class P,
           class U = decltype(std::declval<P>()(typename Forest::value_type()))>
 auto transcribe(const Forest& f, P&& proj) {
-    typename Forest::template rebind<U>::type result;
+    stlab::forest<U> result;
     forests::transform(std::cbegin(f), std::cend(f), forests::inserter(result),
                        std::forward<P>(proj), [](const auto& p) { return is_leading(p); });
     return result;

--- a/stlab/forest_algorithms.hpp
+++ b/stlab/forest_algorithms.hpp
@@ -31,7 +31,7 @@ bool equal_shape(const Forest1& x, const Forest2& y) {
 
 /**************************************************************************************************/
 
-template<class Container>
+template <class Container>
 struct insert_iterator {
     using iterator_category = std::output_iterator_tag;
     using value_type = void;
@@ -43,8 +43,15 @@ struct insert_iterator {
     insert_iterator(Container& c, typename Container::iterator i) : _c{&c}, _i{std::move(i)} {}
 
     constexpr auto& operator*() { return *this; }
-    constexpr auto& operator++() { ++_i; return *this; }
-    constexpr auto operator++(int) { auto result{*this}; ++_i; return result; }
+    constexpr auto& operator++() {
+        ++_i;
+        return *this;
+    }
+    constexpr auto operator++(int) {
+        auto result{*this};
+        ++_i;
+        return result;
+    }
 
     constexpr insert_iterator<Container>& operator=(const typename Container::value_type& value) {
         _i = _c->insert(_i, value);
@@ -63,7 +70,7 @@ private:
     typename Container::iterator _i;
 };
 
-template<class Container>
+template <class Container>
 auto inserter(Container& c) {
     return forests::insert_iterator(c, c.begin());
 }
@@ -89,8 +96,8 @@ template <class Forest,
           class U = decltype(std::declval<P>()(typename Forest::value_type()))>
 auto transcribe(const Forest& f, P&& proj) {
     typename Forest::template rebind<U>::type result;
-    forests::transform(std::cbegin(f), std::cend(f), forests::inserter(result), std::forward<P>(proj),
-                       [](const auto& p) { return is_leading(p); });
+    forests::transform(std::cbegin(f), std::cend(f), forests::inserter(result),
+                       std::forward<P>(proj), [](const auto& p) { return is_leading(p); });
     return result;
 }
 
@@ -115,7 +122,8 @@ template <class I, // I models ForwardIterator; I::value_type == stlab::optional
           class F> // F models Forest
 auto unflatten(I first, I last, F& f) {
     return forests::transform(
-        first, last, forests::inserter(f), [](const auto& x) { return *x; }, [](const auto& p) { return *p; });
+        first, last, forests::inserter(f), [](const auto& x) { return *x; },
+        [](const auto& p) { return *p; });
 }
 
 /**************************************************************************************************/

--- a/stlab/forest_algorithms.hpp
+++ b/stlab/forest_algorithms.hpp
@@ -1,0 +1,122 @@
+/**************************************************************************************************/
+
+#ifndef STLAB_FOREST_ALGORITHMS_HPP
+#define STLAB_FOREST_ALGORITHMS_HPP
+
+/**************************************************************************************************/
+
+// stdc++
+#include <optional>
+
+// stlab
+#include <stlab/forest.hpp>
+
+/**************************************************************************************************/
+
+namespace stlab {
+
+/**************************************************************************************************/
+// "Congruent" would be a nice name here, but in geometry that also implies reflection.
+template <class Forest1, class Forest2>
+bool equal_shape(const Forest1& x, const Forest2& y) {
+    if (x.size_valid() && y.size_valid() && x.size() != y.size()) return false;
+    auto pos{y.begin()};
+    for (auto first(x.begin()), last(x.end()); first != last; ++first, ++pos) {
+        if (first.edge() != pos.edge()) return false;
+    }
+    return true;
+}
+
+/**************************************************************************************************/
+
+template <class Forest>
+struct forest_insert_iterator {
+    using value_type = typename Forest::value_type;
+    using iterator_type = typename Forest::iterator;
+
+    explicit forest_insert_iterator(Forest& f) : _f{f}, _p{_f.root()} {}
+
+    auto& operator*() { return *this; }
+
+    auto& operator++() {
+        ++_p;
+        return *this;
+    }
+
+    auto& operator=(value_type&& x) {
+        _p = _f.insert(_p, std::forward<value_type>(x));
+        return *this;
+    }
+
+    void trailing() { _p = trailing_of(_p); }
+
+private:
+    Forest& _f;
+    iterator_type _p;
+};
+
+template <class Forest>
+auto forest_inserter(Forest& f) {
+    return forest_insert_iterator(f);
+}
+
+/**************************************************************************************************/
+
+template <class I, class O, class P, class UP>
+auto transform_forest(I first, I last, O out, P&& proj, UP&& pred) {
+    for (; first != last; ++first) {
+        ++out;
+        if (pred(first)) {
+            *out = proj(*first);
+        } else {
+            out.trailing();
+        }
+    }
+    return out;
+}
+
+/**************************************************************************************************/
+
+template <class Forest,
+          class P,
+          class U = decltype(std::declval<P>()(typename Forest::value_type()))>
+auto transcribe_forest(const Forest& f, P&& proj) {
+    typename Forest::template rebind<U>::type result;
+    transform_forest(f.begin(), f.end(), forest_inserter(result), std::forward<P>(proj),
+                     [](auto p) { return is_leading(p); });
+    return result;
+}
+
+/**************************************************************************************************/
+
+template <class I, // models ForestFullorderIterator
+          class O> // models OutputIterator
+auto flatten(I first, I last, O out) {
+    for (; first != last; ++first) {
+        if (is_leading(first)) {
+            *out++ = *first;
+        } else {
+            *out++ = std::nullopt;
+        }
+    }
+    return out;
+}
+
+/**************************************************************************************************/
+
+template <class I, // I models ForwardIterator; I::value_type == std::optional<T>
+          class O> // O models ForestOutputIterator
+auto unflatten(I first, I last, O out) {
+    return transform_forest(
+        first, last, out, [](auto x) { return *x; }, [](auto p) { return *p; });
+}
+
+/**************************************************************************************************/
+
+} // namespace stlab
+
+/**************************************************************************************************/
+
+#endif // STLAB_FOREST_ALGORITHMS_HPP
+
+/**************************************************************************************************/

--- a/test/forest_test.cpp
+++ b/test/forest_test.cpp
@@ -466,7 +466,7 @@ BOOST_AUTO_TEST_CASE(test_flatten) {
 
     decltype(f1) f2;
 
-    forests::unflatten(flat.begin(), flat.end(), forests::make_inserter(f2));
+    forests::unflatten(flat.begin(), flat.end(), f2);
 
     BOOST_CHECK(f1 == f2);
 }

--- a/test/forest_test.cpp
+++ b/test/forest_test.cpp
@@ -445,10 +445,12 @@ BOOST_AUTO_TEST_CASE(test_equal_shape) {
 
 BOOST_AUTO_TEST_CASE(test_transcribe_forest) {
     auto f1{big_test_forest()};
-    auto f2{forests::transcribe(f1, [](const std::string& x){
+    stlab::forest<std::size_t> f2;
+
+    forests::transcribe(f1, forests::inserter(f2), [](const std::string& x){
         assert(!x.empty());
         return static_cast<std::size_t>(x.front());
-    })};
+    });
 
     BOOST_CHECK(forests::equal_shape(f1, f2));
     BOOST_CHECK(to_string(f2) == "65666770707171727267687373747475756869696665");

--- a/test/forest_test.cpp
+++ b/test/forest_test.cpp
@@ -447,7 +447,7 @@ BOOST_AUTO_TEST_CASE(test_transcribe_forest) {
     auto f1{big_test_forest()};
     stlab::forest<std::size_t> f2;
 
-    forests::transcribe(f1, forests::inserter(f2), [](const std::string& x){
+    forests::transcribe(f1, forests::transcriber(f2), [](const std::string& x){
         assert(!x.empty());
         return static_cast<std::size_t>(x.front());
     });

--- a/test/forest_test.cpp
+++ b/test/forest_test.cpp
@@ -21,7 +21,7 @@ namespace {
 /**************************************************************************************************/
 
 template <typename T>
-void print(const stlab::forest<T>& f) {
+void print(const forest<T>& f) {
     auto first{f.begin()};
     auto last{f.end()};
     std::size_t depth{0};
@@ -119,17 +119,17 @@ namespace detail {
 /**************************************************************************************************/
 
 template <typename T>
-inline auto to_string(const T& x) {
+auto to_string(const T& x) {
     return std::to_string(x);
 }
 
 template <>
-inline auto to_string(const std::string& x) {
+auto to_string(const std::string& x) {
     return x;
 }
 
 template <>
-inline auto to_string(const std::optional<std::string>& x) {
+auto to_string(const std::optional<std::string>& x) {
     return x ? to_string(*x) : "?";
 }
 
@@ -140,7 +140,7 @@ inline auto to_string(const std::optional<std::string>& x) {
 /**************************************************************************************************/
 
 template <typename R>
-inline auto to_string(const R& r) {
+auto to_string(const R& r) {
     std::string result;
     for (const auto& x : r) {
         result += detail::to_string(x);
@@ -149,7 +149,7 @@ inline auto to_string(const R& r) {
 }
 
 template <typename I>
-inline auto to_string(I first, I last) {
+auto to_string(I first, I last) {
     std::string result;
     while (first != last) {
         result += *first++;
@@ -437,7 +437,7 @@ BOOST_AUTO_TEST_CASE(test_equal_shape) {
     }
 
     BOOST_CHECK(f1 != f2);
-    BOOST_CHECK(equal_shape(f1, f2));
+    BOOST_CHECK(forests::equal_shape(f1, f2));
     BOOST_CHECK(to_string(f2) == "XXXXXXXXXXXXXXXXXXXXXX");
 }
 
@@ -445,12 +445,12 @@ BOOST_AUTO_TEST_CASE(test_equal_shape) {
 
 BOOST_AUTO_TEST_CASE(test_transcribe_forest) {
     auto f1{big_test_forest()};
-    auto f2{stlab::transcribe_forest(f1, [](const std::string& x){
+    auto f2{forests::transcribe(f1, [](const std::string& x){
         assert(!x.empty());
         return static_cast<std::size_t>(x.front());
     })};
 
-    BOOST_CHECK(equal_shape(f1, f2));
+    BOOST_CHECK(forests::equal_shape(f1, f2));
     BOOST_CHECK(to_string(f2) == "65666770707171727267687373747475756869696665");
 }
 
@@ -460,13 +460,13 @@ BOOST_AUTO_TEST_CASE(test_flatten) {
     auto f1{big_test_forest()};
     std::vector<std::optional<std::string>> flat;
 
-    stlab::flatten(f1.begin(), f1.end(), std::back_inserter(flat));
+    forests::flatten(f1.begin(), f1.end(), std::back_inserter(flat));
 
     BOOST_CHECK(to_string(flat) == "ABCF?G?H??DI?J?K??E???");
 
     decltype(f1) f2;
 
-    stlab::unflatten(flat.begin(), flat.end(), stlab::forest_inserter(f2));
+    forests::unflatten(flat.begin(), flat.end(), forests::make_inserter(f2));
 
     BOOST_CHECK(f1 == f2);
 }


### PR DESCRIPTION
Adding a handful of algorithms that have been useful when dealing with forests:

- `equal_shape`: Determine if two forests have the same shape without considering the values they hold.
- `forest_inserter`: Forest output iterator similar to `std::back_inserter`
- `transform_forest`: Algorithm to be used with `forest_inserter`; add elements to one forest respecting the shape of another forest.
- `transcribe_forest`: Helper wrapper of `transform_forest`. Given a forest and a projection function, returns a new forest with the same shape as the original forest, where every note has been transformed by the projection.
- `flatten`: Convert a set of forest nodes into a vector. Forest hierarchy is preserved through the use of `std::optional`.
- `unflatten`: Convert a vector of values into a forest. Hierarchy is implied through the use of `std::optional`.