### PR TITLE
Use correct minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 3.8 )
 
 #
 # Here we check whether stlab is being configured in isolation or as a component


### PR DESCRIPTION
Prior to CMake 3.8, meta features that request a specific language standard - `cxx_std_17` in this case - do not exist.

See [CMake 3.8 release notes](https://cmake.org/cmake/help/latest/release/3.8.html#c-c).