### PR TITLE
Avoid check_min_cppstd becase it does not work properly on macOS

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -181,10 +181,14 @@ class StlabLibrariesConan(ConanFile):
         self.output.info("Task System: {}.".format(self.options.task_system))
 
     def build(self):
+        self.output.info("self.options.testing: {}.".format(self.options.testing))
         if self.options.testing:
             cmake = CMake(self)
             cmake.verbose = True
+            self.output.info("*********** self.settings.compiler.cppstd: {}.".format(self.settings.compiler.cppstd))
+            self.output.info("*********** not self.settings.compiler.cppstd: {}.".format(not self.settings.compiler.cppstd))
             if not self.settings.compiler.cppstd:
+                self.output.info("*********** INSIDE IF.")
                 cmake.definitions["CMAKE_CXX_STANDARD"] = 17
                 cmake.definitions["stlab.testing"] = option_on_off(self.options.testing)
                 cmake.definitions["stlab.coverage"] = option_on_off(self.options.coverage)

--- a/conanfile.py
+++ b/conanfile.py
@@ -181,21 +181,16 @@ class StlabLibrariesConan(ConanFile):
         self.output.info("Task System: {}.".format(self.options.task_system))
 
     def build(self):
-        self.output.info("self.options.testing: {}.".format(self.options.testing))
         if self.options.testing:
             cmake = CMake(self)
             cmake.verbose = True
-            self.output.info("*********** self.settings.compiler.cppstd: {}.".format(self.settings.compiler.cppstd))
-            self.output.info("*********** not self.settings.compiler.cppstd: {}.".format(not self.settings.compiler.cppstd))
-            if not self.settings.compiler.cppstd:
-                self.output.info("*********** INSIDE IF.")
-                cmake.definitions["CMAKE_CXX_STANDARD"] = 14
-                cmake.definitions["stlab.testing"] = option_on_off(self.options.testing)
-                cmake.definitions["stlab.coverage"] = option_on_off(self.options.coverage)
-                cmake.definitions["stlab.boost_variant"] = option_on_off(self.options.boost_variant)
-                cmake.definitions["stlab.boost_optional"] = option_on_off(self.options.boost_optional)
-                cmake.definitions["stlab.coroutines"] = option_on_off(self.options.coroutines)
-                cmake.definitions["stlab.task_system"] = self.options.task_system
+            cmake.definitions["CMAKE_CXX_STANDARD"] = 14
+            cmake.definitions["stlab.testing"] = option_on_off(self.options.testing)
+            cmake.definitions["stlab.coverage"] = option_on_off(self.options.coverage)
+            cmake.definitions["stlab.boost_variant"] = option_on_off(self.options.boost_variant)
+            cmake.definitions["stlab.boost_optional"] = option_on_off(self.options.boost_optional)
+            cmake.definitions["stlab.coroutines"] = option_on_off(self.options.coroutines)
+            cmake.definitions["stlab.task_system"] = self.options.task_system
 
             self.output.info("*********** BEFORE configure().")
             cmake.configure()

--- a/conanfile.py
+++ b/conanfile.py
@@ -189,7 +189,7 @@ class StlabLibrariesConan(ConanFile):
             self.output.info("*********** not self.settings.compiler.cppstd: {}.".format(not self.settings.compiler.cppstd))
             if not self.settings.compiler.cppstd:
                 self.output.info("*********** INSIDE IF.")
-                cmake.definitions["CMAKE_CXX_STANDARD"] = 17
+                cmake.definitions["CMAKE_CXX_STANDARD"] = 14
                 cmake.definitions["stlab.testing"] = option_on_off(self.options.testing)
                 cmake.definitions["stlab.coverage"] = option_on_off(self.options.coverage)
                 cmake.definitions["stlab.boost_variant"] = option_on_off(self.options.boost_variant)
@@ -197,9 +197,13 @@ class StlabLibrariesConan(ConanFile):
                 cmake.definitions["stlab.coroutines"] = option_on_off(self.options.coroutines)
                 cmake.definitions["stlab.task_system"] = self.options.task_system
 
+            self.output.info("*********** BEFORE configure().")
             cmake.configure()
+            self.output.info("*********** BEFORE build().")
             cmake.build()
+            self.output.info("*********** BEFORE test().")
             cmake.test(output_on_failure=True)
+            self.output.info("*********** AFTER test().")
 
     def package(self):
         self.copy("*.hpp")

--- a/conanfile.py
+++ b/conanfile.py
@@ -172,8 +172,6 @@ class StlabLibrariesConan(ConanFile):
     def configure(self):
         ConanFile.configure(self)
 
-        tools.check_min_cppstd(self, "14")
-
         self._fix_boost_components()
 
         if self._use_boost():


### PR DESCRIPTION
`tools.check_min_cppstd(self, "14")` is not doing what one would expect, because it is checking which is the default version of the C++ standard. In the case of `apple-clang` is `gnu98`:

https://github.com/conan-io/conan/blob/develop/conans/client/build/cppstd_flags.py#L65

So I recommend we remove this line until it is corrected.