### PR TITLE
Sean parent/set thread name

### DIFF
--- a/stlab/concurrency/config.hpp
+++ b/stlab/concurrency/config.hpp
@@ -16,9 +16,6 @@
 #define STLAB_FEATURE_PRIVATE_OBJC_ARC() 0
 #define STLAB_FEATURE_PRIVATE_COROUTINES() 0
 
-#define STLAB_FEATURE_PRIVATE_THREAD_NAME_APPLE() 0
-#define STLAB_FEATURE_PRIVATE_THREAD_NAME_POSIX() 0
-
 #define STLAB_FEATURE(X) (STLAB_FEATURE_PRIVATE_##X())
 
 /**************************************************************************************************/
@@ -49,18 +46,6 @@
         #pragma message("Unknown version of C++, assuming C++20.")
         #define STLAB_CPP_VERSION_PRIVATE() 20
     #endif
-
-#endif
-
-#if __APPLE__
-
-#undef STLAB_FEATURE_PRIVATE_THREAD_NAME_APPLE
-#define STLAB_FEATURE_PRIVATE_THREAD_NAME_APPLE() 1
-
-#elif defined(__has_include) && __has_include(<pthread.h>)
-
-#undef STLAB_FEATURE_PRIVATE_THREAD_NAME_POSIX
-#define STLAB_FEATURE_PRIVATE_THREAD_NAME_POSIX() 1
 
 #endif
 

--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -10,6 +10,7 @@
 #define STLAB_CONCURRENCY_DEFAULT_EXECUTOR_HPP
 
 #include <stlab/concurrency/config.hpp>
+#include <stlab/concurrency/set_current_thread_name.hpp>
 #include <stlab/concurrency/task.hpp>
 
 #include <cassert>
@@ -36,12 +37,6 @@
 #include <thread>
 #include <vector>
 
-#endif
-
-/**************************************************************************************************/
-
-#if STLAB_FEATURE(THREAD_NAME_POSIX) || STLAB_FEATURE(THREAD_NAME_APPLE)
-#include <pthread.h>
 #endif
 
 /**************************************************************************************************/
@@ -340,11 +335,7 @@ class priority_task_system {
     std::atomic_bool _done{false};
 
     void run(unsigned i) {
-        #if STLAB_FEATURE(THREAD_NAME_POSIX)
-        pthread_setname_np(pthread_self(), "cc.stlab.default_executor");
-        #elif STLAB_FEATURE(THREAD_NAME_APPLE)
-        pthread_setname_np("cc.stlab.default_executor");
-        #endif
+        stlab::set_current_thread_name("cc.stlab.default_executor");
         while (true) {
             task<void()> f;
 

--- a/stlab/concurrency/set_current_thread_name.hpp
+++ b/stlab/concurrency/set_current_thread_name.hpp
@@ -46,7 +46,7 @@ inline void set_current_thread_name(const char* name) {
     /* Should string->wstring be split out to a utility? */
     int count = MultiByteToWideChar(CP_UTF8, 0, name, (int)std::strlen(name), NULL, 0);
     if (count <= 0) return;
-    std::wstring str(count, std::wchar_t());
+    std::wstring str(count, wchar_t{});
     count = MultiByteToWideChar(CP_UTF8, 0, name, (int)std::strlen(name), &str[0], str.size());
     if (count <= 0) return;
 

--- a/stlab/concurrency/set_current_thread_name.hpp
+++ b/stlab/concurrency/set_current_thread_name.hpp
@@ -44,10 +44,11 @@ inline void set_current_thread_name(const char* name) { pthread_setname_np(name)
 
 inline void set_current_thread_name(const char* name) {
     /* Should string->wstring be split out to a utility? */
-    int count = MultiByteToWideChar(CP_UTF8, 0, name, (int)std::strlen(name), NULL, 0);
+    int count = MultiByteToWideChar(CP_UTF8, 0, name, static_cast<int>(std::strlen(name)), NULL, 0);
     if (count <= 0) return;
     std::wstring str(count, wchar_t{});
-    count = MultiByteToWideChar(CP_UTF8, 0, name, (int)std::strlen(name), &str[0], str.size());
+    count = MultiByteToWideChar(CP_UTF8, 0, name, static_cast<int>(std::strlen(name)), &str[0],
+                                static_cast<int>(str.size()));
     if (count <= 0) return;
 
     (void)SetThreadDescription(GetCurrentThread(), str.c_str());

--- a/stlab/concurrency/set_current_thread_name.hpp
+++ b/stlab/concurrency/set_current_thread_name.hpp
@@ -46,7 +46,7 @@ inline void set_current_thread_name(const char* name) {
     /* Should string->wstring be split out to a utility? */
     int count = MultiByteToWideChar(CP_UTF8, 0, name, (int)std::strlen(name), NULL, 0);
     if (count <= 0) return;
-    std::wstring str(count, std::wchar_t{});
+    std::wstring str(count, std::wchar_t());
     int count = MultiByteToWideChar(CP_UTF8, 0, name, (int)std::strlen(name), &str[0], str.size());
     if (count <= 0) return;
 

--- a/stlab/concurrency/set_current_thread_name.hpp
+++ b/stlab/concurrency/set_current_thread_name.hpp
@@ -37,12 +37,12 @@ namespace stlab {
 /**************************************************************************************************/
 #if defined(__APPLE__)
 
-void set_current_thread_name(const char* name) { pthread_setname_np(name); }
+inline void set_current_thread_name(const char* name) { pthread_setname_np(name); }
 
 /**************************************************************************************************/
 #elif defined(_MSC_VER)
 
-void set_current_thread_name(const char* name) {
+inline void set_current_thread_name(const char* name) {
     /* Should string->wstring be split out to a utility? */
     int count = MultiByteToWideChar(CP_UTF8, 0, name, (int)std::strlen(name), NULL, 0);
     if (count <= 0) return;
@@ -56,17 +56,19 @@ void set_current_thread_name(const char* name) {
 /**************************************************************************************************/
 #elif defined(__EMSCRIPTEN__) && defined(__EMSCRIPTEN_PTHREADS__)
 
-void set_current_thread_name(const char* name) { emscripten_set_thread_name(pthread_self(), name); }
+inline void set_current_thread_name(const char* name) {
+    emscripten_set_thread_name(pthread_self(), name);
+}
 
 /**************************************************************************************************/
 #elif defined(__has_include) && __has_include(<pthread.h>)
 
-void set_current_thread_name(const char* name) { pthread_setname_np(pthread_self(), name); }
+inline void set_current_thread_name(const char* name) { pthread_setname_np(pthread_self(), name); }
 
 /**************************************************************************************************/
 #else
 
-void set_current_thread_name(const char*) {}
+inline void set_current_thread_name(const char*) {}
 
 /**************************************************************************************************/
 #endif

--- a/stlab/concurrency/set_current_thread_name.hpp
+++ b/stlab/concurrency/set_current_thread_name.hpp
@@ -12,6 +12,8 @@
 #include <cstring>
 #include <string>
 
+#include <windows.h>
+
 #include <processthreadsapi.h>
 #include <stringapiset.h>
 

--- a/stlab/concurrency/set_current_thread_name.hpp
+++ b/stlab/concurrency/set_current_thread_name.hpp
@@ -47,7 +47,7 @@ inline void set_current_thread_name(const char* name) {
     int count = MultiByteToWideChar(CP_UTF8, 0, name, (int)std::strlen(name), NULL, 0);
     if (count <= 0) return;
     std::wstring str(count, std::wchar_t());
-    int count = MultiByteToWideChar(CP_UTF8, 0, name, (int)std::strlen(name), &str[0], str.size());
+    count = MultiByteToWideChar(CP_UTF8, 0, name, (int)std::strlen(name), &str[0], str.size());
     if (count <= 0) return;
 
     (void)SetThreadDescription(GetCurrentThread(), str.c_str());

--- a/stlab/concurrency/set_current_thread_name.hpp
+++ b/stlab/concurrency/set_current_thread_name.hpp
@@ -1,0 +1,76 @@
+#ifndef STLAB_SET_CURRENT_THREAD_NAME_HPP
+#define STLAB_SET_CURRENT_THREAD_NAME_HPP
+
+/**************************************************************************************************/
+#if defined(__APPLE__)
+
+#include <pthread.h>
+
+/**************************************************************************************************/
+#elif defined(_MSC_VER)
+
+#include <cstring>
+#include <string>
+
+#include <processthreadsapi.h>
+#include <stringapiset.h>
+
+/**************************************************************************************************/
+#elif defined(__EMSCRIPTEN__) && defined(__EMSCRIPTEN_PTHREADS__)
+
+#include <pthread.h>
+
+#include <emscripten/threading.h>
+
+/**************************************************************************************************/
+#elif defined(__has_include) && __has_include(<pthread.h>)
+
+#include <pthread.h>
+
+/**************************************************************************************************/
+#endif
+
+/**************************************************************************************************/
+
+namespace stlab {
+
+/**************************************************************************************************/
+#if defined(__APPLE__)
+
+void set_current_thread_name(const char* name) { pthread_setname_np(name); }
+
+/**************************************************************************************************/
+#elif defined(_MSC_VER)
+
+void set_current_thread_name(const char* name) {
+    /* Should string->wstring be split out to a utility? */
+    int count = MultiByteToWideChar(CP_UTF8, 0, name, (int)std::strlen(name), NULL, 0);
+    if (count <= 0) return;
+    std::wstring str(count, std::wchar_t{});
+    int count = MultiByteToWideChar(CP_UTF8, 0, name, (int)std::strlen(name), &str[0], str.size());
+    if (count <= 0) return;
+
+    (void)SetThreadDescription(GetCurrentThread(), str.c_str());
+}
+
+/**************************************************************************************************/
+#elif defined(__EMSCRIPTEN__) && defined(__EMSCRIPTEN_PTHREADS__)
+
+void set_current_thread_name(const char* name) { emscripten_set_thread_name(pthread_self(), name); }
+
+/**************************************************************************************************/
+#elif defined(__has_include) && __has_include(<pthread.h>)
+
+void set_current_thread_name(const char* name) { pthread_setname_np(pthread_self(), name); }
+
+/**************************************************************************************************/
+#else
+
+void set_current_thread_name(const char*) {}
+
+/**************************************************************************************************/
+#endif
+
+} // namespace stlab
+
+#endif


### PR DESCRIPTION
Fixing setting the thread name for the portable executor for wasm - also added support for windows.