### PR TITLE
Fix future reduction with non copyable types

### DIFF
--- a/test/future_recover_tests.cpp
+++ b/test/future_recover_tests.cpp
@@ -1161,7 +1161,7 @@ BOOST_AUTO_TEST_CASE(future_recover_move_only_with_broken_promise) {
             return std::move(p.second).recover([&check](auto f) {
                 check = true;
                 try {
-                    return *std::move(f.get_try());
+                    return *std::move(f).get_try();
                 } catch (const exception&) {
                     throw;
                 }
@@ -1179,7 +1179,7 @@ BOOST_AUTO_TEST_CASE(future_recover_move_only_with_broken_promise) {
             return std::move(p.second) ^ [&check](auto f) {
                 check = true;
                 try {
-                    return *std::move(f.get_try());
+                    return *std::move(f).get_try();
                 } catch (const exception&) {
                     throw;
                 }

--- a/test/future_tests.cpp
+++ b/test/future_tests.cpp
@@ -637,7 +637,7 @@ BOOST_AUTO_TEST_CASE(future_reduction_with_mutable_task) {
                             [func = std::move(func)]() mutable { return func(); });
     });
 
-    BOOST_REQUIRE_EQUAL(2, *stlab::blocking_get(result).get_try());
+    BOOST_REQUIRE_EQUAL(2, stlab::blocking_get(result));
 }
 
 BOOST_AUTO_TEST_CASE(future_reduction_with_mutable_void_task) {
@@ -676,7 +676,7 @@ BOOST_AUTO_TEST_CASE(future_reduction_with_move_only_mutable_task) {
                             [func = std::move(func)]() mutable { return func(); });
     });
 
-    BOOST_REQUIRE_EQUAL(2, (*stlab::blocking_get(std::move(result)).get_try()).member());
+    BOOST_REQUIRE_EQUAL(2, stlab::blocking_get(std::move(result)).member());
 }
 
 BOOST_AUTO_TEST_CASE(future_reduction_with_move_only_mutable_void_task) {
@@ -725,15 +725,9 @@ BOOST_AUTO_TEST_CASE(future_reduction_with_move_only_type) {
         bool defused_ = false;
     };
 
-    auto result = stlab::async(stlab::default_executor,
-                               [] {
-                                   return stlab::async(stlab::default_executor,
-                                                       [] { return move_issue_catcher{}; });
-                               })
-                      // force reduction (call reduce)
-                      // TODO (sguy): reduction should be automatic, just like
-                      // with `then` and `reduce`
-                      .then(stlab::immediate_executor, [](auto v) { return v; });
+    auto result = stlab::async(stlab::default_executor, [] {
+        return stlab::async(stlab::default_executor, [] { return move_issue_catcher{}; });
+    });
 
     BOOST_REQUIRE(stlab::blocking_get(std::move(result)).defuse());
 }

--- a/test/future_when_all_arguments_tests.cpp
+++ b/test/future_when_all_arguments_tests.cpp
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(future_when_all_args_move_only_with_one_element) {
   check_valid_future(sut);
   wait_until_future_completed(sut);
 
-  BOOST_REQUIRE_EQUAL(42 + 42, (*sut.get_try()).member());
+  BOOST_REQUIRE_EQUAL(42 + 42, (*std::move(sut).get_try()).member());
   BOOST_REQUIRE_LE(1, custom_scheduler<0>::usage_counter());
   BOOST_REQUIRE_LE(1, custom_scheduler<1>::usage_counter());
 }
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(future_when_all_args_move_only_with_many_elements) {
   check_valid_future(sut);
   wait_until_future_completed(sut);
 
-  BOOST_REQUIRE_EQUAL(1 * 7 + 2 * 11 + 3 * 13 + 5 * 17, (*sut.get_try()).member());
+  BOOST_REQUIRE_EQUAL(1 * 7 + 2 * 11 + 3 * 13 + 5 * 17, (*std::move(sut).get_try()).member());
   BOOST_REQUIRE_LE(4, custom_scheduler<0>::usage_counter());
   BOOST_REQUIRE_LE(1, custom_scheduler<1>::usage_counter());
 }

--- a/test/future_when_all_range_tests.cpp
+++ b/test/future_when_all_range_tests.cpp
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(future_when_all_move_range_with_many_elements) {
     wait_until_future_completed(sut);
 
     BOOST_REQUIRE_EQUAL(size_t(4), p);
-    BOOST_REQUIRE_EQUAL(1 + 2 + 3 + 5, (*sut.get_try()).member() );
+    BOOST_REQUIRE_EQUAL(1 + 2 + 3 + 5, (*std::move(sut).get_try()).member());
     BOOST_REQUIRE_LE(4, custom_scheduler<0>::usage_counter());
     BOOST_REQUIRE_LE(1, custom_scheduler<1>::usage_counter());
 }

--- a/test/future_when_any_arguments_tests.cpp
+++ b/test/future_when_any_arguments_tests.cpp
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(future_when_any_move_only_argument_with_one_argument) {
   wait_until_future_completed(sut);
 
   BOOST_REQUIRE_EQUAL(size_t(0), index);
-  BOOST_REQUIRE_EQUAL(4711, (*sut.get_try()).member());
+  BOOST_REQUIRE_EQUAL(4711, (*std::move(sut).get_try()).member());
   BOOST_REQUIRE_LE(1, custom_scheduler<0>::usage_counter());
   BOOST_REQUIRE_LE(1, custom_scheduler<1>::usage_counter());
 }

--- a/test/future_when_any_range_tests.cpp
+++ b/test/future_when_any_range_tests.cpp
@@ -638,7 +638,7 @@ BOOST_AUTO_TEST_CASE(future_when_any_move_only_range_with_diamond_formation_elem
   wait_until_all_tasks_completed();
 
   BOOST_REQUIRE_EQUAL(size_t(1), index);
-  BOOST_REQUIRE_EQUAL(4711 + 2, (*sut.get_try()).member());
+  BOOST_REQUIRE_EQUAL(4711 + 2, (*std::move(sut).get_try()).member());
   BOOST_REQUIRE_LE(2, custom_scheduler<0>::usage_counter());
   BOOST_REQUIRE_LE(1, custom_scheduler<1>::usage_counter());
 }


### PR DESCRIPTION
Stumbled on an issue with future reduction and non copyable type.
I additionally removed the  const ref qualified version of get_try from future of non copyable type interface because this method is dangerous and can easily be misused. 