### PR TITLE
changes required to build and run unit tests on wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 
 # cmake build directory
 build/
+build_wasm/
 
 # clion build directory
 clion_build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,15 @@ project( stlab VERSION 1.6.2 LANGUAGES CXX )
 # set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if(EMSCRIPTEN)
+  set(CMAKE_AR "emar")
+  set(CMAKE_RANLIB "emranlib")
+  set(CXX_target "em")
+  set(CC_target "emcc")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_TEST_DISABLE_ALT_STACK=1 -s USE_PTHREADS=1")
+  SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -DBOOST_TEST_DISABLE_ALT_STACK=1 -s WASM=1 -s USE_PTHREADS=1 -s EXIT_RUNTIME=1 -s INITIAL_MEMORY=2047MB -s DEMANGLE_SUPPORT=1 -O2")
+endif()
+
 include( CTest )
 include( CMakeDependentOption )
 
@@ -65,7 +74,7 @@ add_library( stlab::stlab ALIAS stlab )
 
 #
 # stlab requires C++17 support, at a minimum. Setting the `cxx_std_17` compile
-# features ensures that the corresponding C++ standard flag is populated in
+# features ensures that the corresponding C standard flag is populated in
 # targets linking to stlab.
 #
 # target_compile_features( stlab INTERFACE cxx_std_14)
@@ -92,7 +101,7 @@ target_link_libraries( stlab INTERFACE Threads::Threads )
 # Several definitions are specified for the microsoft compiler. These have
 # the following effects.
 #
-# + NOMINMAX
+#  + NOMINMAX
 #    disable the `min` and `max` macros defined in the windows.h header
 #
 target_compile_definitions( stlab INTERFACE $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX> )

--- a/cmake/stlab/coroutines.cmake
+++ b/cmake/stlab/coroutines.cmake
@@ -1,10 +1,16 @@
 add_library( coroutines INTERFACE )
 add_library( stlab::coroutines ALIAS coroutines )
 
-include( stlab/coroutines/AppleClang )
-include( stlab/coroutines/Clang )
-include( stlab/coroutines/GNU )
-include( stlab/coroutines/MSVC )
+if(NOT EMSCRIPTEN)
+  include( stlab/coroutines/AppleClang )
+  include( stlab/coroutines/Clang )
+  include( stlab/coroutines/GNU )
+  include( stlab/coroutines/MSVC )
+endif()
+
+if(EMSCRIPTEN)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTLAB_FUTURE_COROUTINES=0")
+endif()
 
 if( stlab.coroutines )
   #

--- a/setup_xcode_cpp14.sh
+++ b/setup_xcode_cpp14.sh
@@ -8,3 +8,12 @@ conan install .. --build=missing -s build_type=Debug -o testing=True -s compiler
 cmake -GXcode -D CMAKE_BUILD_TYPE=debug -D stlab_testing=ON ..
 
 popd
+
+
+mkdir -p build_wasm
+pushd build_wasm
+
+# -DCMAKE_FIND_ROOT_PATH=$PATH_TO_BOOST_BUILT_BY_EMSCRIPTEN
+emcmake cmake -DCMAKE_BUILD_TYPE=Release -Dstlab_testing=ON -DCONAN_DISABLE_CHECK_COMPILER=1 .. && make && ctest --timeout 60 --verbose
+
+popd

--- a/setup_xcode_cpp17.sh
+++ b/setup_xcode_cpp17.sh
@@ -8,3 +8,11 @@ conan install .. --build=missing -s build_type=Debug -o testing=True -s compiler
 cmake -GXcode -D CMAKE_BUILD_TYPE=debug -D stlab_testing=ON ..
 
 popd
+
+mkdir -p build_wasm
+pushd build_wasm
+
+# -DCMAKE_FIND_ROOT_PATH=$PATH_TO_BOOST_BUILT_BY_EMSCRIPTEN
+emcmake cmake -DCMAKE_BUILD_TYPE=Release -Dstlab_testing=ON -DCONAN_DISABLE_CHECK_COMPILER=1 .. && make && ctest --timeout 60 --verbose
+
+popd

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,10 +18,16 @@ endif()
 
 target_link_libraries( stlab.test.channel PUBLIC stlab::testing )
 
-add_test(
+if(EMSCRIPTEN)
+  add_test(NAME stlab.test.channel
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} --experimental-wasm-threads --experimental-wasm-bulk-memory $<TARGET_FILE:stlab.test.channel>
+  )
+else()
+  add_test(
     NAME stlab.test.channel
     COMMAND ${CMAKE_COMMAND} -DTEST_EXECUTABLE=$<TARGET_FILE:stlab.test.channel> -P ${CMAKE_SOURCE_DIR}/cmake/RunTests.cmake
-)
+  )
+endif()
 
 
 ################################################################################
@@ -34,10 +40,17 @@ target_compile_definitions(stlab.test.executor PRIVATE STLAB_UNIT_TEST)
 
 target_link_libraries( stlab.test.executor PUBLIC stlab::testing )
 
-add_test(
+if(EMSCRIPTEN)
+  add_test(NAME stlab.test.executor
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} --experimental-wasm-threads --experimental-wasm-bulk-memory $<TARGET_FILE:stlab.test.executor>
+  )
+else()
+  add_test(
     NAME stlab.test.executor
     COMMAND ${CMAKE_COMMAND} -DTEST_EXECUTABLE=$<TARGET_FILE:stlab.test.executor> -P ${CMAKE_SOURCE_DIR}/cmake/RunTests.cmake
-)
+  )
+endif()
+
 
 ################################################################################
 
@@ -61,10 +74,16 @@ target_compile_definitions(stlab.test.future PRIVATE STLAB_UNIT_TEST)
 
 target_link_libraries( stlab.test.future PUBLIC stlab::testing )
 
-add_test(
+if(EMSCRIPTEN)
+  add_test(NAME stlab.test.future
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} --experimental-wasm-threads --experimental-wasm-bulk-memory $<TARGET_FILE:stlab.test.future>
+  )
+else()
+  add_test(
     NAME stlab.test.future
     COMMAND ${CMAKE_COMMAND} -DTEST_EXECUTABLE=$<TARGET_FILE:stlab.test.future> -P ${CMAKE_SOURCE_DIR}/cmake/RunTests.cmake
-)
+  )
+endif()
 
 
 ################################################################################
@@ -76,10 +95,16 @@ target_compile_definitions(stlab.test.serial_queue PRIVATE STLAB_UNIT_TEST)
 
 target_link_libraries( stlab.test.serial_queue PUBLIC stlab::testing )
 
-add_test(
+if(EMSCRIPTEN)
+  add_test(NAME stlab.test.serial_queue
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} --experimental-wasm-threads --experimental-wasm-bulk-memory $<TARGET_FILE:stlab.test.serial_queue>
+  )
+else()
+  add_test(
     NAME stlab.test.serial_queue
     COMMAND ${CMAKE_COMMAND} -DTEST_EXECUTABLE=$<TARGET_FILE:stlab.test.serial_queue> -P ${CMAKE_SOURCE_DIR}/cmake/RunTests.cmake
-)
+  )
+endif()
 
 ################################################################################
 
@@ -91,10 +116,16 @@ target_compile_definitions(stlab.test.cow PRIVATE STLAB_UNIT_TEST)
 
 target_link_libraries( stlab.test.cow PUBLIC stlab::testing )
 
-add_test(
+if(EMSCRIPTEN)
+  add_test(NAME stlab.test.cow
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} --experimental-wasm-threads --experimental-wasm-bulk-memory $<TARGET_FILE:stlab.test.cow>
+  )
+else()
+  add_test(
     NAME stlab.test.cow
     COMMAND ${CMAKE_COMMAND} -DTEST_EXECUTABLE=$<TARGET_FILE:stlab.test.cow> -P ${CMAKE_SOURCE_DIR}/cmake/RunTests.cmake
-)
+  )
+endif()
 
 
 ################################################################################
@@ -107,10 +138,16 @@ target_compile_definitions(stlab.test.task PRIVATE STLAB_UNIT_TEST)
 
 target_link_libraries( stlab.test.task PUBLIC stlab::testing )
 
-add_test(
+if(EMSCRIPTEN)
+  add_test(NAME stlab.test.task
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} --experimental-wasm-threads --experimental-wasm-bulk-memory $<TARGET_FILE:stlab.test.task>
+  )
+else()
+  add_test(
     NAME stlab.test.task
     COMMAND ${CMAKE_COMMAND} -DTEST_EXECUTABLE=$<TARGET_FILE:stlab.test.task> -P ${CMAKE_SOURCE_DIR}/cmake/RunTests.cmake
-)
+  )
+endif()
 
 ################################################################################
 
@@ -122,10 +159,16 @@ target_compile_definitions(stlab.test.channel PRIVATE STLAB_UNIT_TEST)
 
 target_link_libraries( stlab.test.tuple PUBLIC stlab::testing )
 
-add_test(
+if(EMSCRIPTEN)
+  add_test(NAME stlab.test.tuple
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} --experimental-wasm-threads --experimental-wasm-bulk-memory $<TARGET_FILE:stlab.test.tuple>
+  )
+else()
+  add_test(
     NAME stlab.test.tuple
     COMMAND ${CMAKE_COMMAND} -DTEST_EXECUTABLE=$<TARGET_FILE:stlab.test.tuple> -P ${CMAKE_SOURCE_DIR}/cmake/RunTests.cmake
-)
+  )
+endif()
 
 ################################################################################
 
@@ -137,10 +180,16 @@ target_compile_definitions(stlab.test.channel PRIVATE STLAB_UNIT_TEST)
 
 target_link_libraries( stlab.test.traits PUBLIC stlab::testing )
 
-add_test(
+if(EMSCRIPTEN)
+  add_test(NAME stlab.test.traits
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} --experimental-wasm-threads --experimental-wasm-bulk-memory $<TARGET_FILE:stlab.test.traits>
+  )
+else()
+  add_test(
     NAME stlab.test.traits
     COMMAND ${CMAKE_COMMAND} -DTEST_EXECUTABLE=$<TARGET_FILE:stlab.test.traits> -P ${CMAKE_SOURCE_DIR}/cmake/RunTests.cmake
-)
+  )
+endif()
 
 ################################################################################
 
@@ -150,10 +199,16 @@ add_executable( stlab.test.forest
 
 target_link_libraries( stlab.test.forest PUBLIC stlab::testing )
 
-add_test(
+if(EMSCRIPTEN)
+  add_test(NAME stlab.test.forest
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} --experimental-wasm-threads --experimental-wasm-bulk-memory $<TARGET_FILE:stlab.test.forest>
+  )
+else()
+  add_test(
     NAME stlab.test.forest
     COMMAND ${CMAKE_COMMAND} -DTEST_EXECUTABLE=$<TARGET_FILE:stlab.test.forest> -P ${CMAKE_SOURCE_DIR}/cmake/RunTests.cmake
-)
+  )
+endif()
 
 ################################################################################
 #


### PR DESCRIPTION
Apart from these changes, we also need to build boost for wasm. Steps -

1. Clone boost repo.
2. Make changes in file `boost/libs/test/include/boost/test/impl`
  * Replace both occurrences of `-#ifdef BOOST_TEST_USE_ALT_STACK` with `#if 0` or do something equivalent.
3. `cd` to boost repo root.
4. Run commands - 
  * `./bootstrap.sh`
  * `./b2 toolset=emscripten --with-test --prefix=$PATH_WHERE_YOU_WANT_TO_INSTALL install`

Once we have boost, we need to specify `$PATH_WHERE_YOU_WANT_TO_INSTALL` in the `setup_xcode_cpp14.sh` and `setup_xcode_cpp17.sh` files.