### PR TITLE
Make copy_on_write default c'tor be noexcept-correct.

### DIFF
--- a/stlab/copy_on_write.hpp
+++ b/stlab/copy_on_write.hpp
@@ -26,10 +26,10 @@ class copy_on_write {
     struct model {
         std::atomic<std::size_t> _count{1};
 
-        model() = default;
+        model() noexcept(std::is_nothrow_constructible_v<T>) = default;
 
         template <class... Args>
-        explicit model(Args&&... args) : _value(std::forward<Args>(args)...) {}
+        explicit model(Args&&... args) noexcept(std::is_nothrow_constructible_v<T, Args&&...>) : _value(std::forward<Args>(args)...) {}
 
         T _value;
     };
@@ -48,7 +48,7 @@ public:
 
     using element_type = T;
 
-    copy_on_write() {
+    copy_on_write() noexcept(std::is_nothrow_constructible_v<T>) {
         static model default_s;
         _self = &default_s;
 

--- a/test/cow_test.cpp
+++ b/test/cow_test.cpp
@@ -187,6 +187,20 @@ BOOST_AUTO_TEST_CASE(copy_on_write_interface) {
     using namespace stlab;
 
     {
+        // noexcept-correct default construction:
+        static_assert(noexcept(int()), "int() had better be noexcept!");
+        static_assert(noexcept(copy_on_write<int>()), "Default c'tor should be noexcept if the type's c'tor is.");
+        struct not_noexcept_ctor {
+            not_noexcept_ctor() { throw std::exception(); }
+        };
+        static_assert(!noexcept(not_noexcept_ctor()), "Default c'tor should be noexcept if the type is noexcept.");
+        static_assert(!noexcept(copy_on_write<not_noexcept_ctor>()), "Default c'tor shouldn't be noexcept if the type's c'tor isn't.");
+        BOOST_CHECK_THROW([] {
+          copy_on_write<not_noexcept_ctor> ctor_will_throw;
+        }(), std::exception);
+    }
+
+    {
         // default construction
         copy_on_write<int> a;
         copy_on_write<int> b;


### PR DESCRIPTION
This allows `copy_on_write<T>` to be default constructed without exception provided `T` can be.