### PR TITLE
Remove forcing of pre-C++11-ABI for GCC

### DIFF
--- a/cmake/stlab/development/GNU.cmake
+++ b/cmake/stlab/development/GNU.cmake
@@ -1,4 +1,4 @@
-set( stlab_GNU_base_flags -Wall -Wextra -Wpedantic -Werror -ftemplate-backtrace-limit=0 -D_GLIBCXX_USE_CXX11_ABI=0)
+set( stlab_GNU_base_flags -Wall -Wextra -Wpedantic -Werror -ftemplate-backtrace-limit=0 )
 set( stlab_GNU_debug_flags -gdwarf-3 )
 set( stlab_GNU_coverage_flags --coverage )
 set( stlab_GNU_release_flags )


### PR DESCRIPTION
Modern Linux distributions, such as Ubuntu 22.04, use the C++11 ABI. This makes
STLab libraries fail at link time due to incompatibility with the stock Boost
libraries. Removing the `-D_GLIBCXX_USE_CXX11_ABI=0` flag fixes the issue.