### PR TITLE
Remove support for threadless platforms

### DIFF
--- a/stlab/concurrency/set_current_thread_name.hpp
+++ b/stlab/concurrency/set_current_thread_name.hpp
@@ -25,7 +25,7 @@
 #include <emscripten/threading.h>
 
 /**************************************************************************************************/
-#elif defined(__has_include) && __has_include(<pthread.h>)
+#else
 
 #include <pthread.h>
 
@@ -64,14 +64,9 @@ inline void set_current_thread_name(const char* name) {
 }
 
 /**************************************************************************************************/
-#elif defined(__has_include) && __has_include(<pthread.h>)
-
-inline void set_current_thread_name(const char* name) { pthread_setname_np(pthread_self(), name); }
-
-/**************************************************************************************************/
 #else
 
-inline void set_current_thread_name(const char*) {}
+inline void set_current_thread_name(const char* name) { pthread_setname_np(pthread_self(), name); }
 
 /**************************************************************************************************/
 #endif


### PR DESCRIPTION
CMakeLists.txt already prevents builds on threadless platforms, so this change
completes removal by cutting the relevant code as well. This is part of an
attempt to remove all uses of __has_include to prevent ODR violations. See #399.