### PR TITLE
Bump Clang and Ubuntu versions in CI

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -4,13 +4,13 @@
             "name": "Linux GCC 10",
             "compiler": "gcc",
             "version": "10",
-            "os": "ubuntu-20.04"
+            "os": "ubuntu-22.04"
         },
         {
-            "name": "Linux Clang 11",
+            "name": "Linux Clang 14",
             "compiler": "clang",
-            "version": "11",
-            "os": "ubuntu-20.04"
+            "version": "14",
+            "os": "ubuntu-22.04"
         },
         {
             "name": "macOS apple-clang 12.0",

--- a/.github/workflows/stlab.yml
+++ b/.github/workflows/stlab.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   generate-matrix:
     name: Generate Job Matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/stlab.yml
+++ b/.github/workflows/stlab.yml
@@ -72,7 +72,7 @@ jobs:
         shell: bash
         run: |
           echo "CONAN_CLANG_VERSIONS=${{ matrix.config.version }}" >> $GITHUB_ENV
-          echo "CONAN_DOCKER_IMAGE=conanio/clang${{ matrix.config.version }}" >> $GITHUB_ENV
+          echo "CONAN_DOCKER_IMAGE=conanio/clang${{ matrix.config.version }}-ubuntu16.04" >> $GITHUB_ENV
 
       - name: Settting EnvVars (macOS)
         if: ${{ matrix.config.compiler == 'apple-clang' }}


### PR DESCRIPTION
GCC wasn't bumped because there's a compilation issue that needs to be
resolved at a later time.