### PR TITLE
Don't include stlab/coroutines if they aren't enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,8 +193,11 @@ message(STATUS "stlab: Task System: ${stlab.task_system}")
 
 
 list( APPEND CMAKE_MODULE_PATH "${stlab_SOURCE_DIR}/cmake" )
-include( stlab/coroutines )
-target_link_libraries( stlab INTERFACE stlab::coroutines )
+
+if( stlab.coroutines )
+  include( stlab/coroutines )
+  target_link_libraries( stlab INTERFACE stlab::coroutines )
+endif()
 
 if ( stlab.testing )
   include( stlab/development )
@@ -248,7 +251,8 @@ write_basic_package_version_file(
 # generate a CMake configuration file for consumption by CMake's `find_package`
 # intrinsic
 #
-install( TARGETS stlab coroutines EXPORT stlabTargets )
+
+install( TARGETS stlab EXPORT stlabTargets )
 
 #
 # Non-testing header files (preserving relative paths) are installed to the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,7 +252,11 @@ write_basic_package_version_file(
 # intrinsic
 #
 
-install( TARGETS stlab EXPORT stlabTargets )
+if( stlab.coroutines )
+    install( TARGETS stlab coroutines EXPORT stlabTargets )
+else()
+    install( TARGETS stlab EXPORT stlabTargets )
+endif()
 
 #
 # Non-testing header files (preserving relative paths) are installed to the


### PR DESCRIPTION
This fixes an issue where the STLAB_FUTURE_COROUTINES variable is set to 1 even
when stlab.coroutines is OFF. This causes a compilation failure on apple-clang
13.0.1 compilations.

The coroutines target installation was removed as this caused a
compilation error when stlab.coroutines is OFF and didn't have any
discernable impact.