### PR TITLE
Make macos CI configuration use vanilla CMake

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -13,10 +13,10 @@
             "os": "ubuntu-22.04"
         },
         {
-            "name": "macOS apple-clang 12.0",
+            "name": "macOS apple-clang 13.0.1",
             "compiler": "apple-clang",
-            "version": "12.0",
-            "os": "macos-10.15"
+            "version": "13.0.1",
+            "os": "macos-11"
         },
         {
             "name": "Windows VS2019",

--- a/.github/workflows/stlab.yml
+++ b/.github/workflows/stlab.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Install Dependencies (macos)
         if: ${{ startsWith(matrix.config.os, 'macos') }}
         run: |
-          chmod +x .github/install.sh
-          .github/install.sh
+          brew install boost
+          brew install ninja
         shell: bash
 
       - name: Install Dependencies (ubuntu)
@@ -85,7 +85,8 @@ jobs:
         if: ${{ matrix.config.compiler == 'apple-clang' }}
         shell: bash
         run: |
-          echo "CONAN_APPLE_CLANG_VERSIONS=${{ matrix.config.version }}" >> $GITHUB_ENV
+          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+          echo "CXX=$(brew --prefix llvm)/bin/clang++" >> $GITHUB_ENV
 
       - name: Settting EnvVars (Windows)
         if: ${{ matrix.config.compiler == 'Visual Studio' }}
@@ -101,12 +102,18 @@ jobs:
           mkdir build
           cmake -S. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release
 
+      - name: Configure (macos)
+        if: ${{ startsWith(matrix.config.os, 'macos') }}
+        shell: bash
+        run: |
+          mkdir build
+          cmake -S. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release
+
       - name: Build (macos)
         if: ${{ startsWith(matrix.config.os, 'macos') }}
         shell: bash
         run: |
-          chmod +x .github/run.sh
-          .github/run.sh
+          cmake --build build/
 
       - name: Build (ubuntu)
         if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
@@ -116,6 +123,13 @@ jobs:
 
       - name: Test (ubuntu)
         if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
+        shell: bash
+        run: |
+          cd build/
+          ctest
+
+      - name: Test (macos)
+        if: ${{ startsWith(matrix.config.os, 'macos') }}
         shell: bash
         run: |
           cd build/


### PR DESCRIPTION
This removes the dependency on Conan for CI for the macos platform and better represents expected usage. This additionally upgrades the macos platform used within CI.