### PR TITLE
Remove windows-2016 CI support.

### DIFF
--- a/.github/matrix.json
+++ b/.github/matrix.json
@@ -24,13 +24,6 @@
             "version": "16",
             "os": "windows-2019",
             "cmake_toolset": "Visual Studio 16 2019"
-        },
-        {
-            "name": "Windows VS2017",
-            "compiler": "Visual Studio",
-            "version": "15",
-            "os": "windows-2016",
-            "cmake_toolset": "Visual Studio 15 2017 Win64"
         }
     ]
 }


### PR DESCRIPTION
We are no longer having continuous integration against this platform.