### PR TITLE
Use vanilla CMake for Windows CI

### DIFF
--- a/.github/workflows/stlab.yml
+++ b/.github/workflows/stlab.yml
@@ -56,15 +56,8 @@ jobs:
       - name: Install Dependencies (Windows)
         if: ${{ startsWith(matrix.config.os, 'windows') }}
         run: |
-          set PATH=%PYTHON%;%PYTHON%/Scripts/;%PATH%;
-          python.exe --version
-          cmake --version
-          python.exe -m pip install --upgrade pip
-          pip.exe install markupsafe==2.0.1
-          pip.exe install conan_package_tools==0.38.0
-          pip.exe install conan==1.43.0
-          conan --version
-          conan user
+          choco install --yes ninja
+          vcpkg install boost-test:x64-windows boost-multiprecision:x64-windows boost-variant:x64-windows
         shell: cmd
 
       - name: Settting EnvVars (Linux+GCC)
@@ -88,13 +81,6 @@ jobs:
           echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
           echo "CXX=$(brew --prefix llvm)/bin/clang++" >> $GITHUB_ENV
 
-      - name: Settting EnvVars (Windows)
-        if: ${{ matrix.config.compiler == 'Visual Studio' }}
-        shell: powershell
-        run: |
-          echo "CONAN_VISUAL_VERSIONS=${{ matrix.config.version }}" >> $Env:GITHUB_ENV
-          echo "CMAKE_TOOLSET=${{ matrix.config.cmake_toolset }}" >> $Env:GITHUB_ENV
-
       - name: Configure (ubuntu)
         if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
         shell: bash
@@ -109,6 +95,14 @@ jobs:
           mkdir build
           cmake -S. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release
 
+      - name: Configure (windows)
+        if: ${{ startsWith(matrix.config.os, 'windows') }}
+        shell: cmd
+        run: |
+          mkdir build
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          cmake -S. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+
       - name: Build (macos)
         if: ${{ startsWith(matrix.config.os, 'macos') }}
         shell: bash
@@ -119,6 +113,13 @@ jobs:
         if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
         shell: bash
         run: |
+          cmake --build build/
+
+      - name: Build (windows)
+        if: ${{ startsWith(matrix.config.os, 'windows') }}
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           cmake --build build/
 
       - name: Test (ubuntu)
@@ -135,10 +136,9 @@ jobs:
           cd build/
           ctest
 
-      - name: Build (Windows)
+      - name: Test (windows)
         if: ${{ startsWith(matrix.config.os, 'windows') }}
-        shell: powershell
+        shell: bash
         run: |
-          Write-Host "CONAN_VISUAL_VERSIONS: $Env:CONAN_VISUAL_VERSIONS"
-          Write-Host "CMAKE_TOOLSET:         $Env:CMAKE_TOOLSET"
-          python build.py
+          cd build/
+          ctest


### PR DESCRIPTION
Using vcpkg to bring in Boost. Alternatives considered were using
chocolatey and building Boost from source. The former meadured more than
10 minutes to download and the latter added complications that were
unique to Boost.

Used Ninja as a generator. This required utilization of vcvarsall.bat,
but is (a) the fastest built tool, and (b) is used on the other
platforms as well.