### PR TITLE
Remove setup-python action from the stlab workflow

### DIFF
--- a/.github/workflows/stlab.yml
+++ b/.github/workflows/stlab.yml
@@ -35,9 +35,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10.4"
 
       - name: Install Dependencies (macos)
         if: ${{ startsWith(matrix.config.os, 'macos') }}


### PR DESCRIPTION
This is no longer used by any of the jobs and its removal will improve
turnaround.