### PR TITLE
Make several cleanups to stlab.yml

### DIFF
--- a/.github/workflows/stlab.yml
+++ b/.github/workflows/stlab.yml
@@ -5,22 +5,17 @@ on:
   push:
     branches:
     - main
-  
-
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
 
 jobs:
   generate-matrix:
-    name: Generate Job Matrix
+    name: Generate job matrix
     runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
 
-      - name: Generate Job Matrix
+      - name: Generate job matrix
         id: set-matrix
         # Note: The json in this variable must be a single line for parsing to succeed.
         run: echo "::set-output name=matrix::$(cat .github/matrix.json | scripts/flatten_json.py)"
@@ -36,78 +31,65 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Dependencies (macos)
+      - name: Install dependencies (macos)
         if: ${{ startsWith(matrix.config.os, 'macos') }}
         run: |
           brew install boost
           brew install ninja
         shell: bash
 
-      - name: Install Dependencies (ubuntu)
+      - name: Install dependencies (ubuntu)
         if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
         run: |
           sudo apt-get install -y ninja-build
           sudo apt-get install -y libboost-all-dev
         shell: bash
 
-      - name: Install Dependencies (Windows)
+      - name: Install dependencies (Windows)
         if: ${{ startsWith(matrix.config.os, 'windows') }}
         run: |
           choco install --yes ninja
           vcpkg install boost-test:x64-windows boost-multiprecision:x64-windows boost-variant:x64-windows
         shell: cmd
 
-      - name: Settting EnvVars (Linux+GCC)
+      - name: Set enviroment variables (Linux+GCC)
         if: ${{ matrix.config.compiler == 'gcc' }}
         shell: bash
         run: |
           echo "CC=gcc-${{matrix.config.version}}" >> $GITHUB_ENV
           echo "CXX=g++-${{matrix.config.version}}" >> $GITHUB_ENV
 
-      - name: Settting EnvVars (Linux+Clang)
+      - name: Set enviroment variables (Linux+Clang)
         if: ${{ matrix.config.compiler == 'clang' }}
         shell: bash
         run: |
           echo "CC=clang-${{matrix.config.version}}" >> $GITHUB_ENV
           echo "CXX=clang++-${{matrix.config.version}}" >> $GITHUB_ENV
 
-      - name: Settting EnvVars (macOS)
+      - name: Set enviroment variables (MacOS)
         if: ${{ matrix.config.compiler == 'apple-clang' }}
         shell: bash
         run: |
           echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
           echo "CXX=$(brew --prefix llvm)/bin/clang++" >> $GITHUB_ENV
 
-      - name: Configure (ubuntu)
-        if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
+      - name: Configure (Unix)
+        if: ${{ startsWith(matrix.config.os, 'ubuntu') || startsWith(matrix.config.os, 'macos') }}
         shell: bash
         run: |
           mkdir build
           cmake -S. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release
 
-      - name: Configure (macos)
-        if: ${{ startsWith(matrix.config.os, 'macos') }}
-        shell: bash
-        run: |
-          mkdir build
-          cmake -S. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release
-
-      - name: Configure (windows)
+      - name: Configure (Windows)
         if: ${{ startsWith(matrix.config.os, 'windows') }}
         shell: cmd
         run: |
-          mkdir build
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          mkdir build
           cmake -S. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
 
-      - name: Build (macos)
-        if: ${{ startsWith(matrix.config.os, 'macos') }}
-        shell: bash
-        run: |
-          cmake --build build/
-
-      - name: Build (ubuntu)
-        if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
+      - name: Build (Unix)
+        if: ${{ startsWith(matrix.config.os, 'ubuntu') || startsWith(matrix.config.os, 'macos') }}
         shell: bash
         run: |
           cmake --build build/
@@ -119,22 +101,7 @@ jobs:
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           cmake --build build/
 
-      - name: Test (ubuntu)
-        if: ${{ startsWith(matrix.config.os, 'ubuntu') }}
-        shell: bash
-        run: |
-          cd build/
-          ctest
-
-      - name: Test (macos)
-        if: ${{ startsWith(matrix.config.os, 'macos') }}
-        shell: bash
-        run: |
-          cd build/
-          ctest
-
-      - name: Test (windows)
-        if: ${{ startsWith(matrix.config.os, 'windows') }}
+      - name: Test
         shell: bash
         run: |
           cd build/


### PR DESCRIPTION
Removed 'BUILD_TYPE' environment variable. This isn't used as we're now explicit
with our CMake commands on the BUILD_TYPE.

Joined common code between jobs when possible.

Changed the casing in step names and other minor aesthetic improvements.