### PR TITLE
Replace subproject variable with PROJECT_IS_TOP_LEVEL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,4 @@
-cmake_minimum_required( VERSION 3.8 )
-
-#
-# Here we check whether stlab is being configured in isolation or as a component
-# of a larger proeject. To do so, we query whether the `PROJECT_NAME` CMake
-# variable has been defined. In the case it has, we can conclude stlab is a
-# subproject.
-#
-# This convention has been borrowed from the Catch C++ unit testing library.
-#
-if( DEFINED PROJECT_NAME )
-  set( subproject ON )
-else()
-  set( subproject OFF )
-endif()
+cmake_minimum_required( VERSION 3.21 )
 
 project( stlab VERSION 1.6.2 LANGUAGES CXX )
 
@@ -27,11 +13,11 @@ include( CMakeDependentOption )
 #
 cmake_dependent_option( stlab.testing
   "Compile the stlab tests and integrate with ctest"
-  ${BUILD_TESTING} "NOT subproject" OFF )
+  ${BUILD_TESTING} PROJECT_IS_TOP_LEVEL OFF )
 
 cmake_dependent_option( stlab.coverage
   "Enable binary instrumentation to collect test coverage information in the DEBUG configuration"
-  OFF "NOT subproject" OFF )
+  OFF PROJECT_IS_TOP_LEVEL OFF )
 
 option( stlab.boost_variant "Prefer Boost::variant to std::variant" OFF )
 option( stlab.boost_optional "Prefer Boost::optional to std::optional" OFF )


### PR DESCRIPTION
PROJECT_IS_TOP_LEVEL was added in CMake 3.21 and enables this code to be
removed.