### PR TITLE
Remove unused 'CMAKE_THREAD_PREFER_PTHREAD' variable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,6 @@ target_include_directories( stlab INTERFACE
 # target called `Thread::Thread` which transitively supplies inlude directories,
 # compiler flags, and linker flags to CMake targets linking to it.
 #
-set( CMAKE_THREAD_PREFER_PTHREAD TRUE )
 find_package( Threads REQUIRED )
 target_link_libraries( stlab INTERFACE Threads::Threads )
 


### PR DESCRIPTION
The FindThreads CMake module is not impacted by setting this variable as the
original author likely intended. They were probably trying to set
THREADS_PREFER_PTHREAD_FLAG instead. However, due to a lack of rational for
attempting to set this variable, the line is removed here to restore the
default.