### PR TITLE
Bump C++ standard in builds

### DIFF
--- a/.github/workflows/stlab.yml
+++ b/.github/workflows/stlab.yml
@@ -78,7 +78,7 @@ jobs:
         shell: bash
         run: |
           mkdir build
-          cmake -S. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release
+          cmake -S. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=23
 
       - name: Configure (Windows)
         if: ${{ startsWith(matrix.config.os, 'windows') }}
@@ -86,7 +86,7 @@ jobs:
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           mkdir build
-          cmake -S. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+          cmake -S. -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_CXX_STANDARD=23
 
       - name: Build (Unix)
         if: ${{ startsWith(matrix.config.os, 'ubuntu') || startsWith(matrix.config.os, 'macos') }}


### PR DESCRIPTION
This makes our CI jobs more closely reflect how we expect our users to
be building, with the latest compilation options. It also ensures that
the std::variant and std::optional options work properly.