### PR TITLE
Add STLAB_USE_BOOST_CPP17_SHIMS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,30 +12,19 @@ cmake_dependent_option( stlab.coverage
   "Enable binary instrumentation to collect test coverage information in the DEBUG configuration"
   OFF PROJECT_IS_TOP_LEVEL OFF )
 
-option( stlab.boost_variant "Prefer Boost::variant to std::variant" OFF )
-option( stlab.boost_optional "Prefer Boost::optional to std::optional" OFF )
+option( STLAB_USE_BOOST_CPP17_SHIMS "Use variant and optional from Boost instead of std. Useful for non-conforming compilers." OFF )
 option( stlab.coroutines "Leverage the coroutine TS in stlab" OFF )
 
 set(stlab.task_system "header" CACHE STRING "Select the task system (header|portable|libdispatch|emscripten|pnacl|windows).")
 
-#
-# On apple we have to force the usage of boost.variant, because Apple's
-# implementation of C++17 is not complete
-#
-if(APPLE AND (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang") AND CMAKE_CXX_COMPILER_VERSION LESS 12)
-  message(STATUS "Apple-Clang versions less than 12 do not correctly support std::optional or std::variant, so we will use boost::optional and boost::variant instead.")
-  set( stlab.boost_variant ON )
-endif()
-
-mark_as_advanced( stlab.coroutines stlab.boost_variant stlab.boost_optional )
-
+mark_as_advanced( stlab.coroutines )
 
 if( BUILD_TESTING AND NOT Boost_unit_test_framework_FOUND )
   message( SEND_ERROR "BUILD_TESTING is enabled, but an installation of Boost.Test was not found." )
 endif()
 
-if( ( stlab.boost_variant OR stlab.boost_optional ) AND NOT Boost_FOUND )
-  message( SEND_ERROR "stlab.boost_variant OR stlab.boost_optional is enabled, but a Boost installation was not found." )
+if( STLAB_USE_BOOST_CPP17_SHIMS AND NOT Boost_FOUND )
+  message( SEND_ERROR "STLAB_USE_BOOST_CPP17_SHIMS is enabled, but a Boost installation was not found." )
 endif()
 
 #
@@ -74,12 +63,10 @@ target_compile_definitions( stlab INTERFACE $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX> 
 
 add_subdirectory( stlab )
 
-if ( stlab.boost_variant OR stlab.boost_optional )
+if ( STLAB_USE_BOOST_CPP17_SHIMS )
   target_link_libraries( stlab INTERFACE Boost::boost )
 
-  target_compile_definitions( stlab INTERFACE
-    $<$<BOOL:${stlab.boost_optional}>:STLAB_FORCE_BOOST_OPTIONAL>
-    $<$<BOOL:${stlab.boost_variant}>:STLAB_FORCE_BOOST_VARIANT> )
+  target_compile_definitions( stlab INTERFACE STLAB_USE_BOOST_CPP17_SHIMS )
 endif()
 
 if (NOT APPLE AND (${stlab.task_system} STREQUAL "libdispatch"))

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Release changelogs are listed in [CHANGES.md](CHANGES.md).
 -- Visual Studio 2019
 -- gcc (>= 7)
 -- clang (>= 6)
-- boost.optional and boost.variant if the compiler's library does not provide them
-- boost.test only for the unit tests
+- [OPTIONAL] Boost.Optional and Boost.Variant. Required when `STLAB_USE_BOOST_CPP17_SHIMS` is enabled.
+- [OPTIONAL] Boost.Test. Used when `BUILD_TESTING` is enabled.
 
 # Building
 

--- a/stlab/concurrency/optional.hpp
+++ b/stlab/concurrency/optional.hpp
@@ -4,51 +4,20 @@
     (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 */
 
+// The library can be used with boost::optional or std::optional. Usage of
+// boost::optional is enabled when STLAB_USE_BOOST_CPP17_SHIMS is defined.
+
 /**************************************************************************************************/
 
 #ifndef STLAB_CONCURRENCY_OPTIONAL_HPP
 #define STLAB_CONCURRENCY_OPTIONAL_HPP
 
-#include <stlab/concurrency/config.hpp>
-
 /**************************************************************************************************/
 
-#define STLAB_OPTIONAL_PRIVATE_STD() 0
-#define STLAB_OPTIONAL_PRIVATE_STD_EXPERIMENTAL() 1
-#define STLAB_OPTIONAL_PRIVATE_BOOST() 2
-
-/**************************************************************************************************/
-
-#if defined(STLAB_FORCE_BOOST_OPTIONAL)
-    #define STLAB_OPTIONAL_PRIVATE_SELECTION() STLAB_OPTIONAL_PRIVATE_BOOST()
-#elif defined(__has_include) // Check if __has_include is present
-    #if __has_include(<optional>) && STLAB_CPP_VERSION_AT_LEAST(17)
-        #include <optional>
-        #define STLAB_OPTIONAL_PRIVATE_SELECTION() STLAB_OPTIONAL_PRIVATE_STD()
-    #elif __has_include(<experimental/optional>)
-        #include <experimental/optional>
-        #if defined(__cpp_lib_experimental_optional)
-            #define STLAB_OPTIONAL_PRIVATE_SELECTION() STLAB_OPTIONAL_PRIVATE_STD_EXPERIMENTAL()
-        #else
-            #define STLAB_OPTIONAL_PRIVATE_SELECTION() STLAB_OPTIONAL_PRIVATE_BOOST()
-        #endif
-    #else
-        #define STLAB_OPTIONAL_PRIVATE_SELECTION() STLAB_OPTIONAL_PRIVATE_BOOST()
-    #endif
-#else
-    #define STLAB_OPTIONAL_PRIVATE_SELECTION() STLAB_OPTIONAL_PRIVATE_BOOST()
-#endif
-
-#define STLAB_OPTIONAL(X) (STLAB_OPTIONAL_PRIVATE_SELECTION() == STLAB_OPTIONAL_PRIVATE_##X())
-
-/**************************************************************************************************/
-// The library can be used with boost::optional, std::experimental::optional or std::optional.
-// Without any additional define, it uses the versions from the standard, if it is available.
-//
-// If using of boost::optional shall be enforced, define STLAB_FORCE_BOOST_OPTIONAL.
-
-#if STLAB_OPTIONAL(BOOST)
+#ifdef STLAB_USE_BOOST_CPP17_SHIMS
     #include <boost/optional.hpp>
+#else
+    #include <optional>
 #endif
 
 /**************************************************************************************************/
@@ -57,7 +26,7 @@ namespace stlab {
 
 /**************************************************************************************************/
 
-#if STLAB_OPTIONAL(STD)
+#ifndef STLAB_USE_BOOST_CPP17_SHIMS
 
 template <typename T>
 using optional = std::optional<T>;
@@ -66,27 +35,12 @@ constexpr std::nullopt_t nullopt{std::nullopt};
 
 /**************************************************************************************************/
 
-#elif STLAB_OPTIONAL(STD_EXPERIMENTAL)
-
-template <typename T>
-using optional = std::experimental::optional<T>;
-
-constexpr std::experimental::nullopt_t nullopt{std::experimental::nullopt};
-
-/**************************************************************************************************/
-
-#elif STLAB_OPTIONAL(BOOST)
+#else
 
 template <typename T>
 using optional = boost::optional<T>;
 
 const boost::none_t nullopt((boost::none_t::init_tag()));
-
-/**************************************************************************************************/
-
-#else
-
-    #error `optional` variant not specified
 
 #endif
 
@@ -96,6 +50,4 @@ const boost::none_t nullopt((boost::none_t::init_tag()));
 
 /**************************************************************************************************/
 
-#endif
-
-/**************************************************************************************************/
+#endif // STLAB_CONCURRENCY_OPTIONAL_HPP

--- a/stlab/concurrency/variant.hpp
+++ b/stlab/concurrency/variant.hpp
@@ -4,44 +4,20 @@
     (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 */
 
+// The library can be used with boost::variant or std::variant. Usage of
+// boost::variant is enabled when STLAB_USE_BOOST_CPP17_SHIMS is defined.
+
 /**************************************************************************************************/
 
 #ifndef STLAB_CONCURRENCY_VARIANT_HPP
 #define STLAB_CONCURRENCY_VARIANT_HPP
 
-#include <stlab/concurrency/config.hpp>
-
 /**************************************************************************************************/
 
-#define STLAB_VARIANT_PRIVATE_STD() 1
-#define STLAB_VARIANT_PRIVATE_BOOST() 2
-
-/**************************************************************************************************/
-
-#if defined(STLAB_FORCE_BOOST_VARIANT)
-    #define STLAB_VARIANT_PRIVATE_SELECTION() STLAB_VARIANT_PRIVATE_BOOST()
-#elif defined(__has_include) // Check if __has_include is present
-    #if __has_include(<variant>) && STLAB_CPP_VERSION_AT_LEAST(17)
-        #include <variant>
-        #define STLAB_VARIANT_PRIVATE_SELECTION() STLAB_VARIANT_PRIVATE_STD()
-    #else
-        #define STLAB_VARIANT_PRIVATE_SELECTION() STLAB_VARIANT_PRIVATE_BOOST()
-    #endif
+#ifdef STLAB_USE_BOOST_CPP17_SHIMS
+    #include <boost/variant.hpp>
 #else
-    #define STLAB_VARIANT_PRIVATE_SELECTION() STLAB_VARIANT_PRIVATE_BOOST()
-#endif
-
-#define STLAB_VARIANT(X) (STLAB_VARIANT_PRIVATE_SELECTION() == STLAB_VARIANT_PRIVATE_##X())
-
-/**************************************************************************************************/
-
-// The library can be used with boost::variant or std::variant.
-// Without any additional define, it uses the versions from the standard, if it is available.
-//
-// If using of boost::variant shall be enforced, define STLAB_FORCE_BOOST_VARIANT.
-
-#if STLAB_VARIANT(BOOST)
-#include <boost/variant.hpp>
+    #include <variant>
 #endif
 
 /**************************************************************************************************/
@@ -50,7 +26,7 @@ namespace stlab {
 
 /**************************************************************************************************/
 
-#if STLAB_VARIANT(STD)
+#ifndef STLAB_USE_BOOST_CPP17_SHIMS
 
 template <typename... T>
 using variant = std::variant<T...>;
@@ -82,7 +58,7 @@ constexpr auto index(const std::variant<Types...>& v) {
 
 /**************************************************************************************************/
 
-#elif STLAB_VARIANT(BOOST)
+#else
 
 template <typename... T>
 using variant = boost::variant<T...>;
@@ -112,12 +88,6 @@ constexpr auto index(const boost::variant<Types...>& v) {
     return v.which();
 }
 
-/**************************************************************************************************/
-
-#else
-
-    #error `variant` variant not specified
-
 #endif
 
 /**************************************************************************************************/
@@ -127,5 +97,3 @@ constexpr auto index(const boost::variant<Types...>& v) {
 /**************************************************************************************************/
 
 #endif // STLAB_CONCURRENCY_VARIANT_HPP
-
-/**************************************************************************************************/


### PR DESCRIPTION
This replaces the stlab.boost_variant and stlab.boost_optional CMake options as
well as the STLAB_FORCE_BOOST_OPTIONAL and STLAB_FORCE_BOOST_VARIANT defines. It
was done both to reduce the number of build configurations we support and lower
maintenance costs for supporting legacy compilers.

- Support for <experimental/optional> was removed completely. Developers without
  a conforming <optional> header may use STLAB_USE_BOOST_CPP17_SHIMS.
- Logic that detects when STLAB_USE_BOOST_CPP17_SHIMS is required has been
  removed. Those on legacy platforms will need to explicitly specify this option
  when building.