### PR TITLE
Update to Boost 1.74.0, latest supported by `apt-get libboost-all-dev`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include( CTest )
 include( CMakeDependentOption )
 
 find_package( Threads REQUIRED )
-find_package( Boost 1.60.0 OPTIONAL_COMPONENTS unit_test_framework )
+find_package( Boost 1.74.0 OPTIONAL_COMPONENTS unit_test_framework )
 
 cmake_dependent_option( stlab.coverage
   "Enable binary instrumentation to collect test coverage information in the DEBUG configuration"

--- a/cmake/stlabConfig.cmake
+++ b/cmake/stlabConfig.cmake
@@ -1,4 +1,4 @@
 include( CMakeFindDependencyMacro )
-find_dependency(Boost 1.60.0)
+find_dependency(Boost 1.74.0)
 find_dependency(Threads)
 include( "${CMAKE_CURRENT_LIST_DIR}/stlabTargets.cmake" )


### PR DESCRIPTION
See https://packages.debian.org/sid/libboost-all-dev