### PR TITLE
Fix GCC 11 warning

### DIFF
--- a/stlab/concurrency/future.hpp
+++ b/stlab/concurrency/future.hpp
@@ -2012,7 +2012,7 @@ auto operator co_await(stlab::future<R> f) {
                 .detach();
         }
     };
-    return Awaiter{std::move(f)};
+    return Awaiter{std::move(f), {}};
 }
 
 inline auto operator co_await(stlab::future<void> f) {


### PR DESCRIPTION
`Awaiter`'s second data member wasn't being initialized.