### PR TITLE
Make selection of main executor at configure time.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ include( StlabUtil )
 find_package( Boost 1.74.0 OPTIONAL_COMPONENTS unit_test_framework )
 find_package( libdispatch )
 find_package( Threads )
+find_package( Qt6 COMPONENTS Core )
 
 cmake_dependent_option( stlab.coverage
   "Enable binary instrumentation to collect test coverage information in the DEBUG configuration"
@@ -22,6 +23,9 @@ set( STLAB_THREAD_SYSTEM ${STLAB_DEFAULT_THREAD_SYSTEM} CACHE STRING "Thread sys
 
 stlab_detect_task_system(STLAB_DEFAULT_TASK_SYSTEM)
 set(STLAB_TASK_SYSTEM ${STLAB_DEFAULT_TASK_SYSTEM} CACHE STRING "Select the task system (portable|libdispatch|emscripten|windows).")
+
+stlab_detect_main_executor(STLAB_DEFAULT_MAIN_EXECUTOR)
+set(STLAB_MAIN_EXECUTOR ${STLAB_DEFAULT_MAIN_EXECUTOR} CACHE STRING "Select the main executor variant (qt|libdispatch|emscripten|none).")
 
 if( BUILD_TESTING AND NOT Boost_unit_test_framework_FOUND )
   message( SEND_ERROR "BUILD_TESTING is enabled, but an installation of Boost.Test was not found." )
@@ -37,6 +41,18 @@ endif()
 
 if( (STLAB_TASK_SYSTEM STREQUAL "libdispatch") AND NOT libdispatch_FOUND )
   message( SEND_ERROR "STLAB_TASK_SYSTEM is set to \"libdispatch\", but a libdispatch installation was not found." )
+endif()
+
+if( (STLAB_MAIN_EXECUTOR STREQUAL "libdispatch") AND NOT libdispatch_FOUND )
+  message( SEND_ERROR "STLAB_MAIN_EXECUTOR is set to \"libdispatch\", but a libdispatch installation was not found." )
+endif()
+
+if( (STLAB_MAIN_EXECUTOR STREQUAL "emscripten") AND NOT (STLAB_TASK_SYSTEM STREQUAL "emscripten") )
+  message( SEND_ERROR "If STLAB_MAIN_EXECUTOR is set to \"emscripten\", STLAB_TASK_SYSTEM must also be." )
+endif()
+
+if( (STLAB_MAIN_EXECUTOR STREQUAL "qt") AND NOT Qt6Core_FOUND )
+  message( SEND_ERROR "STLAB_MAIN_EXECUTOR is set to \"qt\", but a Qt6 installation was not found." )
 endif()
 
 #
@@ -94,20 +110,34 @@ else ()
 endif()
 
 if (STLAB_TASK_SYSTEM STREQUAL "portable")
-  target_compile_definitions( stlab INTERFACE -DSTLAB_FORCE_TASK_SYSTEM_PORTABLE )
+  target_compile_definitions( stlab INTERFACE STLAB_FORCE_TASK_SYSTEM_PORTABLE )
 elseif (STLAB_TASK_SYSTEM STREQUAL "libdispatch")
-  target_compile_definitions( stlab INTERFACE -DSTLAB_FORCE_TASK_SYSTEM_LIBDISPATCH )
+  target_compile_definitions( stlab INTERFACE STLAB_FORCE_TASK_SYSTEM_LIBDISPATCH )
   target_link_libraries(stlab INTERFACE libdispatch::libdispatch)
 elseif (STLAB_TASK_SYSTEM STREQUAL "emscripten")
-  target_compile_definitions( stlab INTERFACE -DSTLAB_FORCE_TASK_SYSTEM_EMSCRIPTEN )
+  target_compile_definitions( stlab INTERFACE STLAB_FORCE_TASK_SYSTEM_EMSCRIPTEN )
 elseif (STLAB_TASK_SYSTEM STREQUAL "windows")
-  target_compile_definitions( stlab INTERFACE -DSTLAB_FORCE_TASK_SYSTEM_WINDOWS )
+  target_compile_definitions( stlab INTERFACE STLAB_FORCE_TASK_SYSTEM_WINDOWS )
 else()
   message(FATAL_ERROR "Invalid Task System: ${STLAB_TASK_SYSTEM}")
 endif()
 
-message(STATUS "stlab: Task System: ${STLAB_TASK_SYSTEM}")
+if (STLAB_MAIN_EXECUTOR STREQUAL "libdispatch")
+  target_compile_definitions( stlab INTERFACE STLAB_MAIN_EXECUTOR_LIBDISPATCH )
+  target_link_libraries(stlab INTERFACE libdispatch::libdispatch)
+elseif (STLAB_MAIN_EXECUTOR STREQUAL "emscripten")
+  target_compile_definitions( stlab INTERFACE STLAB_MAIN_EXECUTOR_EMSCRIPTEN )
+elseif (STLAB_MAIN_EXECUTOR STREQUAL "qt")
+  target_compile_definitions( stlab INTERFACE STLAB_MAIN_EXECUTOR_QT )
+  target_link_libraries( stlab INTERFACE Qt6::Core )
+elseif (STLAB_MAIN_EXECUTOR STREQUAL "none")
+  target_compile_definitions( stlab INTERFACE STLAB_MAIN_EXECUTOR_NONE )
+else()
+  message(FATAL_ERROR "Invalid main executor variant: ${STLAB_MAIN_EXECUTOR}")
+endif()
 
+message(STATUS "stlab: Task System: ${STLAB_TASK_SYSTEM}")
+message(STATUS "stlab: Main Executor: ${STLAB_MAIN_EXECUTOR}")
 
 if ( BUILD_TESTING )
   include( stlab/development )

--- a/cmake/StlabUtil.cmake
+++ b/cmake/StlabUtil.cmake
@@ -65,3 +65,30 @@ function( stlab_detect_task_system result_var )
   endif()
   set( ${result_var} ${result} PARENT_SCOPE )
 endfunction()
+
+# Find a main executor variant that is compatable with the target platform. The
+# following table shows the correspondence between result values and main
+# executor variants.
+#
+# | Result value | Task system                                |
+# |--------------+--------------------------------------------|
+# | libdispatch  | libdispatch (aka. Grand Central Dispatch ) |
+# | emscripten   | Emscripten's executor                      |
+# | qt           | Qt's event framework                       |
+# | none         | None                                       |
+function( stlab_detect_main_executor result_var )
+  find_package(Qt6 QUIET COMPONENTS Core)
+  stlab_detect_task_system( task_system )
+
+  if( ${task_system} STREQUAL "libdispatch" )
+    set( result "libdispatch")
+  elseif( ${task_system} STREQUAL "emscripten" )
+    set( result "emscripten")
+  elseif( Qt6Core_FOUND )
+    set( result "qt")
+  else()
+    set( result "none")
+  endif()
+
+  set( ${result_var} ${result} PARENT_SCOPE )
+endfunction()

--- a/stlab/concurrency/main_executor.hpp
+++ b/stlab/concurrency/main_executor.hpp
@@ -9,31 +9,14 @@
 #ifndef STLAB_CONCURRENCY_MAIN_EXECUTOR_HPP
 #define STLAB_CONCURRENCY_MAIN_EXECUTOR_HPP
 
-#include <stlab/concurrency/config.hpp>
-
-#define STLAB_MAIN_EXECUTOR_LIBDISPATCH 1
-#define STLAB_MAIN_EXECUTOR_EMSCRIPTEN 2
-#define STLAB_MAIN_EXECUTOR_QT 3
-
-
-#if defined(QT_CORE_LIB) && !defined(STLAB_DISABLE_QT_MAIN_EXECUTOR)
-#define STLAB_MAIN_EXECUTOR STLAB_MAIN_EXECUTOR_QT
-#elif STLAB_TASK_SYSTEM(LIBDISPATCH)
-#define STLAB_MAIN_EXECUTOR STLAB_MAIN_EXECUTOR_LIBDISPATCH
-#elif STLAB_TASK_SYSTEM(EMSCRIPTEN)
-#define STLAB_MAIN_EXECUTOR STLAB_MAIN_EXECUTOR_EMSCRIPTEN
-#else
-#error "Unable to auto-detect main executor"
-#endif
-
-#if STLAB_MAIN_EXECUTOR == STLAB_MAIN_EXECUTOR_QT
+#ifdef STLAB_MAIN_EXECUTOR_QT
 #include <QCoreApplication>
 #include <QEvent>
 #include <stlab/concurrency/task.hpp>
 #include <memory>
-#elif STLAB_MAIN_EXECUTOR == STLAB_MAIN_EXECUTOR_LIBDISPATCH
+#elif defined(STLAB_MAIN_EXECUTOR_LIBDISPATCH)
 #include <dispatch/dispatch.h>
-#elif STLAB_MAIN_EXECUTOR == STLAB_MAIN_EXECUTOR_EMSCRIPTEN
+#elif defined(STLAB_MAIN_EXECUTOR_EMSCRIPTEN)
 #include <stlab/concurrency/default_executor.hpp>
 #endif
 
@@ -51,7 +34,7 @@ namespace detail {
 
 /**************************************************************************************************/
 
-#if STLAB_MAIN_EXECUTOR == STLAB_MAIN_EXECUTOR_QT
+#ifdef STLAB_MAIN_EXECUTOR_QT
 
 class main_executor_type {
     using result_type = void;
@@ -100,7 +83,7 @@ public:
 
 /**************************************************************************************************/
 
-#elif STLAB_MAIN_EXECUTOR == STLAB_MAIN_EXECUTOR_LIBDISPATCH
+#elif defined(STLAB_MAIN_EXECUTOR_LIBDISPATCH)
 
 struct main_executor_type {
     using result_type = void;
@@ -117,15 +100,17 @@ struct main_executor_type {
     }
 };
 
-#elif STLAB_MAIN_EXECUTOR == STLAB_MAIN_EXECUTOR_EMSCRIPTEN
+#elif defined(STLAB_MAIN_EXECUTOR_EMSCRIPTEN
 
 using main_executor_type = default_executor_type;
 
-#endif // STLAB_MAIN_EXECUTOR == STLAB_MAIN_EXECUTOR_QT
+#endif // STLAB_MAIN_EXECUTOR_QT
 
 } // namespace detail
 
+#ifndef STLAB_MAIN_EXECUTOR_NONE
 constexpr auto main_executor = detail::main_executor_type{};
+#endif
 
 } // namespace v1
 


### PR DESCRIPTION
This allows for flexibility beyond the automatic configuration. It also
fixes an issue where the QtCore library wasn't being pulled in properly
when the qt main executor was selected.

* Created the 'stlab_detect_main_executor' function which somewhat
  reproduces the logic previously in main_executor.hpp. The one
  intentional difference is that libdispatch is preferred to qt.
* The STLAB_DEFAULT_MAIN_EXECUTOR CMake CACHE variable was added
  and this controls the new STLAB_MAIN_EXECUTOR_LIBDISPATCH,
  STLAB_MAIN_EXECUTOR_EMSCRIPTEN, STLAB_MAIN_EXECUTOR_QT, and
  STLAB_MAIN_EXECUTOR_NONE preprocessor definitions.