### PR TITLE
Switch command to get clang on macOS 11.6

### DIFF
--- a/.github/workflows/stlab.yml
+++ b/.github/workflows/stlab.yml
@@ -70,8 +70,8 @@ jobs:
         if: ${{ matrix.config.compiler == 'apple-clang' }}
         shell: bash
         run: |
-          echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
-          echo "CXX=$(brew --prefix llvm)/bin/clang++" >> $GITHUB_ENV
+          echo "CC=$(brew --prefix llvm@13)/bin/clang" >> $GITHUB_ENV
+          echo "CXX=$(brew --prefix llvm@13)/bin/clang++" >> $GITHUB_ENV
 
       - name: Configure (Ubuntu)
         if: ${{ startsWith(matrix.config.os, 'ubuntu') }}


### PR DESCRIPTION
This recently changed and broke the build. See
https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md