### PR TITLE
Suppress warnings on MSVC versions supporting C++20

### DIFF
--- a/stlab/config.hpp.in
+++ b/stlab/config.hpp.in
@@ -58,6 +58,8 @@
         #define STLAB_CPP_VERSION_PRIVATE() 14
     #elif _MSC_FULL_VER >= 191225830 && _MSVC_LANG == 201703L
         #define STLAB_CPP_VERSION_PRIVATE() 17
+    #elif _MSVC_LANG == 202002L
+        #define STLAB_CPP_VERSION_PRIVATE() 20
     #else
         #pragma message("Unknown version of C++, assuming C++20.")
         #define STLAB_CPP_VERSION_PRIVATE() 20


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170