### PR TITLE
Remove emscripten task system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,10 @@ stlab_detect_thread_system(STLAB_DEFAULT_THREAD_SYSTEM)
 set( STLAB_THREAD_SYSTEM ${STLAB_DEFAULT_THREAD_SYSTEM} CACHE STRING "Thread system to use (win32|pthread|pthread-emscripten|pthread-apple|none)")
 
 stlab_detect_task_system(STLAB_DEFAULT_TASK_SYSTEM)
-set(STLAB_TASK_SYSTEM ${STLAB_DEFAULT_TASK_SYSTEM} CACHE STRING "Select the task system (portable|libdispatch|emscripten|windows).")
+set(STLAB_TASK_SYSTEM ${STLAB_DEFAULT_TASK_SYSTEM} CACHE STRING "Task system to use (portable|libdispatch|windows).")
 
 stlab_detect_main_executor(STLAB_DEFAULT_MAIN_EXECUTOR)
-set(STLAB_MAIN_EXECUTOR ${STLAB_DEFAULT_MAIN_EXECUTOR} CACHE STRING "Select the main executor variant (qt|libdispatch|emscripten|none).")
+set(STLAB_MAIN_EXECUTOR ${STLAB_DEFAULT_MAIN_EXECUTOR} CACHE STRING "Main executor to use (qt|libdispatch|emscripten|none).")
 
 if( BUILD_TESTING AND NOT Boost_unit_test_framework_FOUND )
   message( SEND_ERROR "BUILD_TESTING is enabled, but an installation of Boost.Test was not found." )
@@ -47,10 +47,6 @@ endif()
 
 if( (STLAB_MAIN_EXECUTOR STREQUAL "libdispatch") AND NOT libdispatch_FOUND )
   message( SEND_ERROR "STLAB_MAIN_EXECUTOR is set to \"libdispatch\", but a libdispatch installation was not found." )
-endif()
-
-if( (STLAB_MAIN_EXECUTOR STREQUAL "emscripten") AND NOT (STLAB_TASK_SYSTEM STREQUAL "emscripten") )
-  message( SEND_ERROR "If STLAB_MAIN_EXECUTOR is set to \"emscripten\", STLAB_TASK_SYSTEM must also be." )
 endif()
 
 if( (STLAB_MAIN_EXECUTOR STREQUAL "qt") AND NOT Qt6Core_FOUND )

--- a/cmake/StlabUtil.cmake
+++ b/cmake/StlabUtil.cmake
@@ -142,7 +142,7 @@ endfunction()
 # following table shows the correspondence between result values and main
 # executor variants.
 #
-# | Result value | Task system                                |
+# | Result value | Main Executor                              |
 # |--------------+--------------------------------------------|
 # | libdispatch  | libdispatch (aka. Grand Central Dispatch ) |
 # | emscripten   | Emscripten's executor                      |

--- a/cmake/StlabUtil.cmake
+++ b/cmake/StlabUtil.cmake
@@ -114,24 +114,19 @@ endfunction()
 # to the result. The following table shows the correspondence between result
 # values and task systems.
 #
-# | Result value | Task system                                |
-# |--------------+--------------------------------------------|
-# | libdispatch  | libdispatch (aka. Grand Central Dispatch ) |
-# | portable     | A portable task system provided by stlab   |
-# | emscripten   | Emscripten's task system                   |
-# | windows      | Windows's task system                      |
+# | Result value | Task system                                                    |
+# |--------------+----------------------------------------------------------------|
+# | libdispatch  | libdispatch (aka. Grand Central Dispatch )                     |
+# | portable     | A portable task system provided by stlab (supports Emscripten) |
+# | windows      | Windows's task system                                          |
 function( stlab_detect_task_system result_var )
   find_package( Threads QUIET )
   if( APPLE )
     set( result "libdispatch")
-  elseif( CMAKE_SYSTEM_NAME STREQUAL "Emscripten" )
-    if( Threads_FOUND )
-      set( result "emscripten")
-    else()
-      set( result "portable")
-    endif()
   elseif( WIN32 )
     set( result "windows")
+  elseif( CMAKE_SYSTEM_NAME STREQUAL "Emscripten" )
+    set( result "portable")
   else()
     find_package( libdispatch )
     if( libdispatch_FOUND )
@@ -159,7 +154,7 @@ function( stlab_detect_main_executor result_var )
 
   if( task_system STREQUAL "libdispatch" )
     set( result "libdispatch")
-  elseif( task_system STREQUAL "emscripten" )
+  elseif( CMAKE_SYSTEM_NAME STREQUAL "Emscripten" )
     set( result "emscripten")
   elseif( Qt6Core_FOUND )
     set( result "qt")

--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -19,20 +19,16 @@
 
 #if STLAB_TASK_SYSTEM(LIBDISPATCH)
 #include <dispatch/dispatch.h>
-#elif STLAB_TASK_SYSTEM(EMSCRIPTEN)
-#include <emscripten.h>
 #elif STLAB_TASK_SYSTEM(WINDOWS)
 #include <Windows.h>
 #include <memory>
 #elif STLAB_TASK_SYSTEM(PORTABLE)
-
 #include <algorithm>
 #include <atomic>
 #include <climits>
 #include <condition_variable>
 #include <thread>
 #include <vector>
-
 #endif
 
 /**************************************************************************************************/
@@ -106,29 +102,6 @@ struct executor_type {
                                    (*f)();
                                    delete f;
                                });
-    }
-};
-
-/**************************************************************************************************/
-
-#elif STLAB_TASK_SYSTEM(EMSCRIPTEN)
-
-template <executor_priority P = executor_priority::medium>
-struct executor_type {
-    using result_type = void;
-
-    template <typename F>
-    void operator()(F f) const {
-        // REVISIT (sparent) : Using a negative timeout may give better performance. Need to test.
-        using f_t = decltype(f);
-
-        emscripten_async_call(
-            [](void* f_) {
-                auto f = static_cast<f_t*>(f_);
-                (*f)();
-                delete f;
-            },
-            new f_t(std::move(f)), 0);
     }
 };
 

--- a/stlab/concurrency/system_timer.hpp
+++ b/stlab/concurrency/system_timer.hpp
@@ -19,8 +19,6 @@
 
 #if STLAB_TASK_SYSTEM(LIBDISPATCH)
 #include <dispatch/dispatch.h>
-#elif STLAB_TASK_SYSTEM(EMSCRIPTEN)
-#include <emscripten.h>
 #elif STLAB_TASK_SYSTEM(WINDOWS)
 #include <Windows.h>
 #include <memory>
@@ -81,10 +79,6 @@ struct system_timer_type {
             });
     }
 };
-
-/**************************************************************************************************/
-
-#elif STLAB_TASK_SYSTEM(EMSCRIPTEN)
 
 /**************************************************************************************************/
 


### PR DESCRIPTION
the emscripten task system option was broken and it was determined that the portable option is sufficient for WASM. This is being done as part of the project to get WASM support working properly. See issue #445 and #405 