### PR TITLE
Remove unnecessary CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,14 +130,6 @@ if ( BUILD_TESTING )
     stlab::development
     stlab::stlab )
 
-  #
-  # Linking to the Boost unit test framework requires an additional
-  # preprocessor definition when the unit test compiled resources are
-  # provided by a shared library rather than a static library.
-  #
-  target_compile_definitions( testing INTERFACE
-    $<$<NOT:$<BOOL:${Boost_USE_STATIC_LIBS}>>:BOOST_TEST_DYN_LINK>)
-
   add_subdirectory( test )
 endif()
 


### PR DESCRIPTION
Following [this commit](https://github.com/stlab/libraries/commit/28ae88eb462d3215c6f28848311d2b6c1430df5b), I removed this presumably unnecessary CMake config, but I don't know enough about CMake patterns to know for sure it's unnecessary. The sub-comment on the referenced commit suggests more research is necessary.

The presence of this rule caused WASM to not link, due to a missing main() symbol. Removing it does not appear to break CI. 