### PR TITLE
new API: bool packaged_task::canceled() const

### DIFF
--- a/stlab/concurrency/future.hpp
+++ b/stlab/concurrency/future.hpp
@@ -721,6 +721,10 @@ public:
         if (p) (*p)(std::forward<A>(args)...);
     }
 
+    bool canceled() const {
+        return _p.expired();
+    }
+
     void set_exception(std::exception_ptr error) const {
         auto p = _p.lock();
         if (p) p->set_error(std::move(error));


### PR DESCRIPTION
This API allows the caller to tell when the associated `future` has been destroyed.