### PR TITLE
Changes to support C++14 and fixed missing include file (#501)

### DIFF
--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -367,6 +367,11 @@ public:
         }
     }
 
+    // An alternative spelling of the default constructor because void isn't regular
+    // and C++14 requires a copy-ctor even when it must be elided. This allows us to
+    // "manually" elide the copy-ctor.
+    priority_task_system(nullptr_t) : priority_task_system() {}
+
     void join() {
         for (auto& e : _q)
             e.done();
@@ -429,11 +434,9 @@ public:
 };
 
 inline priority_task_system& pts() {
-    static priority_task_system only_task_system{[]{
-        at_pre_exit([]() noexcept {
-            only_task_system.join();
-        });
-        return priority_task_system{};
+    static priority_task_system only_task_system{[] {
+        at_pre_exit([]() noexcept { only_task_system.join(); });
+        return nullptr;
     }()};
     return only_task_system;
 }

--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -370,7 +370,7 @@ public:
     // An alternative spelling of the default constructor because void isn't regular
     // and C++14 requires a copy-ctor even when it must be elided. This allows us to
     // "manually" elide the copy-ctor.
-    priority_task_system(nullptr_t) : priority_task_system() {}
+    priority_task_system(std::nullptr_t) : priority_task_system() {}
 
     void join() {
         for (auto& e : _q)
@@ -452,10 +452,8 @@ struct executor_type {
     using result_type = void;
 
     void operator()(task<void()> f) const {
-        static task_system<P> only_task_system{[]{
-            at_pre_exit([]() noexcept {
-                only_task_system.join();
-            });
+        static task_system<P> only_task_system{[] {
+            at_pre_exit([]() noexcept { only_task_system.join(); });
             return task_system<P>{};
         }()};
         only_task_system(std::move(f));

--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -318,6 +318,8 @@ public:
 
 /**************************************************************************************************/
 
+/// A portable, scalable, priority task system.
+
 class priority_task_system {
     // _count is the number of threads in the thread pool
     // it is at least 1 but usually number of cores - 1 reserved for the main thread
@@ -359,7 +361,7 @@ class priority_task_system {
     }
 
 public:
-    // Initialize the task system with
+    /// Create an instance of the task system.
     priority_task_system() {
         _threads.reserve(_thread_limit);
         for (unsigned n = 0; n != _count; ++n) {
@@ -367,9 +369,9 @@ public:
         }
     }
 
-    // An alternative spelling of the default constructor because void isn't regular
-    // and C++14 requires a copy-ctor even when it must be elided. This allows us to
-    // "manually" elide the copy-ctor.
+    /// Create an instance of the task system. Alternative spelling of the default constructor
+    /// because void isn't regular and C++14 requires a copy-ctor even when it must be elided. This
+    /// allows us to "manually" elide the copy-ctor. See the immediate executed lambda in `pts()`
     priority_task_system(std::nullptr_t) : priority_task_system() {}
 
     void join() {
@@ -433,7 +435,12 @@ public:
     }
 };
 
+/// Returns an instance of the task system singleton. An immediately executed lambda is used
+/// to register the the task system for tear down pre-exit in a thread safe manner.
+
 inline priority_task_system& pts() {
+    // Uses the `nullptr` constructor with an immediate executed lambda to register the task
+    // system in a thread safe manner.
     static priority_task_system only_task_system{[] {
         at_pre_exit([]() noexcept { only_task_system.join(); });
         return nullptr;

--- a/stlab/concurrency/optional.hpp
+++ b/stlab/concurrency/optional.hpp
@@ -12,6 +12,8 @@
 #ifndef STLAB_CONCURRENCY_OPTIONAL_HPP
 #define STLAB_CONCURRENCY_OPTIONAL_HPP
 
+#include <stlab/config.hpp>
+
 /**************************************************************************************************/
 
 #include <stlab/config.hpp>


### PR DESCRIPTION
Fixed issue in portable default_executor requiring a copy-ctor for an elided construction. Issue #501 
Added missing config.hpp include in optional.hpp which is required for C++14 to get boost optional.
Changed `_v` traits in copy_on_write.hpp to use `::value` instead for C++14.

All C++14 unit tests now pass on macOS with the portable executor.