### PR TITLE
Changed CMake paths to be robust to subprojects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ add_library( stlab::stlab ALIAS stlab )
 #
 target_include_directories( stlab INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
   $<INSTALL_INTERFACE:include> )
 
 #

--- a/cmake/StlabUtil.cmake
+++ b/cmake/StlabUtil.cmake
@@ -201,8 +201,8 @@ function( stlab_generate_config_file )
   endif()
 
   configure_file(
-    "${CMAKE_SOURCE_DIR}/stlab/config.hpp.in"
-    "${CMAKE_BINARY_DIR}/stlab/config.hpp"
+    "${PROJECT_SOURCE_DIR}/stlab/config.hpp.in"
+    "${PROJECT_BINARY_DIR}/stlab/config.hpp"
     @ONLY
   )
 endfunction()

--- a/stlab/CMakeLists.txt
+++ b/stlab/CMakeLists.txt
@@ -46,7 +46,7 @@ stlab_generate_config_file()
 target_sources( stlab INTERFACE
   FILE_SET stlab
   TYPE HEADERS
-  BASE_DIRS ${CMAKE_BINARY_DIR}
+  BASE_DIRS ${PROJECT_BINARY_DIR}
   FILES
-    ${CMAKE_BINARY_DIR}/stlab/config.hpp
+    ${PROJECT_BINARY_DIR}/stlab/config.hpp
 )


### PR DESCRIPTION
Replaced CMAKE_SOURCE_DIR and CMAKE_BINARY_DIR with PROJECT_SOURCE_DIR and PROJECT_BINARY_DIR respectively. 
CMAKE_SOURCE_DIR will not point to the source directory of stlab if it's integrated as a subproject in a different repository which makes the paths invalid