### PR TITLE
Disable write for const qualified underlying type

### DIFF
--- a/stlab/copy_on_write.hpp
+++ b/stlab/copy_on_write.hpp
@@ -45,6 +45,10 @@ class copy_on_write {
     using disable_copy_assign =
         std::enable_if_t<!std::is_same<std::decay_t<U>, copy_on_write>::value, copy_on_write&>;
 
+    template <typename element_type>
+    using disable_write =
+        std::enable_if_t<!std::is_const_v<element_type> && std::is_same_v<T, element_type>, element_type&>;
+
 public:
     /* [[deprecated]] */ using value_type = T;
 
@@ -100,7 +104,8 @@ public:
         return *this = copy_on_write(std::forward<U>(x));
     }
 
-    auto write() -> element_type& {
+    template <typename U = element_type>
+    auto write() -> disable_write<U> {
         if (!unique()) *this = copy_on_write(read());
 
         return _self->_value;


### PR DESCRIPTION
If the underlying type is `const` qualified I feel `write()` should be disabled. I haven't thought about this much but shouldn't `const copy_on_write<Type>` and `copy_on_write<const Type>` be semantically the same?