### PR TITLE
Fix typo from main_scheduler_type to main_executor_type

### DIFF
--- a/stlab/concurrency/main_executor.hpp
+++ b/stlab/concurrency/main_executor.hpp
@@ -106,7 +106,7 @@ struct main_executor_type {
 
 #elif STLAB_MAIN_EXECUTOR(EMSCRIPTEN)
 
-struct main_scheduler_type {
+struct main_executor_type {
     using result_type = void;
 
     template <class F>


### PR DESCRIPTION
Fixes https://github.com/stlab/libraries/issues/514