### PR TITLE
Compilation fix for `future::then(executor, f)`

### DIFF
--- a/stlab/concurrency/future.hpp
+++ b/stlab/concurrency/future.hpp
@@ -829,7 +829,7 @@ public:
     template <typename E, typename F>
     auto then(E&& executor, F&& f) const& {
         return recover(std::forward<E>(executor),
-                       [_f = std::forward<F>(f)](future<result_type>&& p) {
+                       [_f = std::forward<F>(f)](future<result_type>&& p) mutable {
                            (void)std::move(p).get_try();
                            return std::move(_f)();
                        });

--- a/stlab/concurrency/future.hpp
+++ b/stlab/concurrency/future.hpp
@@ -682,7 +682,7 @@ public:
     template <typename E, typename F>
     auto then(E&& executor, F&& f) const& {
         return recover(std::forward<E>(executor),
-                       [_f = std::forward<F>(f)](future<result_type>&& p) {
+                       [_f = std::forward<F>(f)](future<result_type>&& p) mutable {
                            return std::move(_f)(*std::move(p).get_try());
                        });
     }


### PR DESCRIPTION
The implementation of `future::then(E&& executor, F&& f)` constructs a lambda that is not mutable, but then calls `std::move(_f)`. On Xcode 13.4.1, this causes a compilation error because the lambda is `const`. Making the lambda `mutable` resolves the issue.