### PR TITLE
Revisit Reduce

### DIFF
--- a/test/future_tests.cpp
+++ b/test/future_tests.cpp
@@ -664,7 +664,7 @@ BOOST_AUTO_TEST_CASE(future_reduction_with_mutable_task) {
                             [func = std::move(func)]() mutable { return func(); });
     });
 
-    BOOST_REQUIRE_EQUAL(2, *stlab::await(result).get_try());
+    BOOST_REQUIRE_EQUAL(2, stlab::await(result));
 }
 
 BOOST_AUTO_TEST_CASE(future_reduction_with_mutable_void_task) {
@@ -702,7 +702,7 @@ BOOST_AUTO_TEST_CASE(future_reduction_with_move_only_mutable_task) {
                             [func = std::move(func)]() mutable { return func(); });
     });
 
-    BOOST_REQUIRE_EQUAL(2, (*stlab::await(std::move(result)).get_try()).member());
+    BOOST_REQUIRE_EQUAL(2, stlab::await(std::move(result)).member());
 }
 
 BOOST_AUTO_TEST_CASE(future_reduction_with_move_only_mutable_void_task) {


### PR DESCRIPTION
I reimplemented the reduce mechanism as a (manually written) coroutine and added reduce as a feature to async.

The executor is now set correctly on the reduced future so continuations will execute where the wrapping future would have executed.

Reduce is now an independent algorithm but not exposed as the intention is to always auto-reduce and the mechanism may get pushed lower in the future.

The key insight was to rethink the reduction as:
```
auto reduce(E e, future<future<R>>&& r) -> future<R> {
  return async(e, [](future<future<R>>&& r) -> task<R> {
        co_return co_await co_await move(r);
    });
}
```
The above may be implementable directly with coroutines in the future. For now, I implemented it with a manual coroutine.

