### PR TITLE
Build with C++14 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required( VERSION 3.23 )
 
 project( stlab VERSION 1.7.1 LANGUAGES CXX )
 
+# Default to C++14
+if( NOT DEFINED CMAKE_CXX_STANDARD )
+  set( CMAKE_CXX_STANDARD 14 )
+endif()
+
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" )
 include( CTest )
 include( CMakeDependentOption )


### PR DESCRIPTION
To avoid breaking C++14 compatibility and to ensure consistent behavior across toolchains I think it would be useful to specify a default standard to use for building (which can still be overridden of course).