### PR TITLE
General Cleanup

### DIFF
--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -163,13 +163,13 @@ public:
 
     template <typename F>
     void operator()(F&& f) {
-        auto f = std::make_unique<F>(std::forward<F>(f));
-        auto work = CreateThreadpoolWork(&callback_impl<F>, f.get(), &_callBackEnvironment);
+        auto p = std::make_unique<F>(std::forward<F>(f));
+        auto work = CreateThreadpoolWork(&callback_impl<F>, p.get(), &_callBackEnvironment);
 
         if (work == nullptr) {
             throw std::bad_alloc();
         }
-        f.release(); // ownership was passed to thread
+        p.release(); // ownership was passed to thread
         SubmitThreadpoolWork(work);
     }
 
@@ -180,7 +180,6 @@ private:
                                        PTP_WORK work) {
         std::unique_ptr<F> f(static_cast<F*>(parameter));
         (*f)();
-        delete f;
         CloseThreadpoolWork(work);
     }
 };

--- a/stlab/concurrency/default_executor.hpp
+++ b/stlab/concurrency/default_executor.hpp
@@ -101,7 +101,7 @@ struct executor_type {
 
         dispatch_group_async_f(detail::group()._group,
                                dispatch_get_global_queue(platform_priority(P), 0),
-                               new f_t(std::foward<F>(f)), [](void* f_) {
+                               new f_t(std::forward<F>(f)), [](void* f_) {
                                    auto f = static_cast<f_t*>(f_);
                                    (*f)();
                                    delete f;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,7 +48,8 @@ add_executable( stlab.test.future
   future_when_any_range_tests.cpp
   tuple_algorithm_test.cpp
   main.cpp
-  future_test_helper.hpp )
+  future_test_helper.hpp
+  future_reduction_tests.cpp)
 
 if( NOT STLAB_NO_STD_COROUTINES )
   target_sources( stlab.test.future PUBLIC future_coroutine_tests.cpp )

--- a/test/future_reduction_tests.cpp
+++ b/test/future_reduction_tests.cpp
@@ -1,0 +1,25 @@
+/*
+    Copyright 2015 Adobe
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/**************************************************************************************************/
+
+#include <stlab/concurrency/future.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <stlab/concurrency/utility.hpp>
+
+using namespace stlab;
+
+BOOST_AUTO_TEST_SUITE(reduction_tests)
+
+BOOST_AUTO_TEST_CASE(void_void_reduction) {
+    auto f = make_ready_future(immediate_executor) |
+             [] { return make_ready_future(immediate_executor); };
+    BOOST_REQUIRE(!f.exception());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Some lint fixes for CodeQL (used in the chain library CI).
- Cleaned up mutex usage in `await()` to eliminate a flag and directly protect the element being modified.
- Fixed a memory leak in the Windows default executor and a potential leak if scheduling work fails.
- Made package_task<> move-only, simplifying promise by removing the promise count.
- Removed unused reduction_failed error code.
- Added a reduction test for future<future<void>>