### PR TITLE
add move implementation which asserts on providing const argument

### DIFF
--- a/docs/libraries/utility.hpp/f_move.md
+++ b/docs/libraries/utility.hpp/f_move.md
@@ -1,0 +1,28 @@
+---
+layout: function
+title: move
+hyde:
+  owner: dhaibatc
+  brief: __INLINED__
+  tags:
+    - function
+  inline:
+    brief:
+      - A standard move implementation but with a compile-time check for const types.
+  defined_in_file: utility.hpp
+  overloads:
+    "template <class T>\nconstexpr std::remove_reference_t<T> && move(T &&)":
+      arguments:
+        - description: __OPTIONAL__
+          name: t
+          type: T &&
+      description: __INLINED__
+      inline:
+        description:
+          - A standard move implementation but with a compile-time check for const types.
+      return: __OPTIONAL__
+      signature_with_names: "template <class T>\nconstexpr std::remove_reference_t<T> && move(T && t)"
+  namespace:
+    - stlab
+    - v2
+---

--- a/stlab/utility.hpp
+++ b/stlab/utility.hpp
@@ -126,6 +126,16 @@ constexpr std::decay_t<T> copy(T&& value) noexcept(noexcept(std::decay_t<T>{
 
 /**************************************************************************************************/
 
+/// A standard move implementation but with a compile-time check for const types.
+template <class T>
+constexpr std::remove_reference_t<T>&& move(T&& t) noexcept {
+    static_assert(!std::is_const_v<std::remove_reference_t<T>>,
+                  "move of const type will unintentionally decay to copy");
+    return static_cast<std::remove_reference_t<T>&&>(t);
+}
+
+/**************************************************************************************************/
+
 } // namespace STLAB_VERSION_NAMESPACE()
 } // namespace stlab
 


### PR DESCRIPTION
Many a times programmers apply `std::move` on a `const-lvalue` or `lvalue-const-reference`, either directly or indirectly (lambda captures are implicitly immutable, unless the lambda is marked `mutable`), expecting the move-constructor or move-assignment to kick in, but that does not happen.
This version of `stlab::move(moved_object);` compile-time asserts when the type passed is `const`