### PR TITLE
always_true is defined statically in 2 tests.

### DIFF
--- a/test/channel_process_tests.cpp
+++ b/test/channel_process_tests.cpp
@@ -331,9 +331,10 @@ struct process_with_set_error {
 
     [[nodiscard]] static auto state() { return stlab::await_forever; }
 };
-} // namespace
 
 bool always_true{true}; // used to avoid unused variable warning
+
+} // namespace
 
 BOOST_AUTO_TEST_CASE(int_channel_process_set_error_is_called_on_upstream_error) {
     BOOST_TEST_MESSAGE("int channel process set_error is called on upstream error");

--- a/test/future_tests.cpp
+++ b/test/future_tests.cpp
@@ -555,7 +555,9 @@ BOOST_AUTO_TEST_CASE(future_wait_moveonly_value_and_timeout) {
     BOOST_REQUIRE_EQUAL(42, r.get_try()->member());
 }
 
+namespace {
 bool always_true{true}; // used to avoid unused variable warning
+}
 
 BOOST_AUTO_TEST_CASE(future_wait_moveonly_value_error_case_and_timeout) {
     BOOST_TEST_MESSAGE("future wait with moveonly value and timeout set");


### PR DESCRIPTION
this PR avoids a duplicate symbol error when compiling all tests into a single binary