### PR TITLE
fix STLAB_CPP_VERSION and future.hpp.

### DIFF
--- a/include/stlab/concurrency/future.hpp
+++ b/include/stlab/concurrency/future.hpp
@@ -144,12 +144,12 @@ inline auto Future_error_map(future_error_codes code) noexcept -> const
 /**************************************************************************************************/
 
 // This could be lifted into a common header if needed in other places
-#if __cplusplus < 201703L
-template <class F, class... Args>
-using result_t = std::result_of_t<F(Args...)>;
-#else
+#if STLAB_CPP_VERSION_AT_LEAST(17)
 template <class F, class... Args>
 using result_t = std::invoke_result_t<F, Args...>;
+#else
+template <class F, class... Args>
+using result_t = std::result_of_t<F(Args...)>;
 #endif
 
 /**************************************************************************************************/

--- a/include/stlab/config.hpp.in
+++ b/include/stlab/config.hpp.in
@@ -55,52 +55,46 @@
 #define STLAB_CPP_VERSION_AT_LEAST(X) (STLAB_CPP_VERSION_PRIVATE() >= (X))
 
 #if __APPLE__
-
 #if defined(__has_feature)
 #if __has_feature(objc_arc)
 #undef STLAB_FEATURE_PRIVATE_OBJC_ARC
 #define STLAB_FEATURE_PRIVATE_OBJC_ARC() 1
-#endif
-#endif
+#endif  // _has_feature(objc_arc)
+#endif  // __has_feature
+#endif  // __APPLE__
 
-#elif _MSC_VER
-
-#if _MSVC_LANG == 201103L
-#define STLAB_CPP_VERSION_PRIVATE() 11
-#elif _MSVC_LANG == 201402L
-#define STLAB_CPP_VERSION_PRIVATE() 14
-#elif _MSC_FULL_VER >= 191225830 && _MSVC_LANG == 201703L
+// Check C++ language standard, e.g. C++17 vs. C++20/23.
+//
+// Note that on Windows the value for __cplusplus is only set properly if /Zc:__cplusplus is set.
+// This should be the case with the most projects setup but we're not taking any chances.
+// https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+//
+// For MSVS for now there is no c++23 only /std:c++latest which is
+// "It's set to a higher, unspecified value when the /std:c++latest option is specified."
+// Newer compiler has /std:c++23preview, but we are not using it yet.
+#if (defined(__cplusplus) && __cplusplus >= 202302L) || (defined(_MSVC_LANG) && _MSVC_LANG > 202002L)
+#pragma message "oops The value of STLAB_CPP_VERSION: 23"
+#define STLAB_CPP_VERSION_PRIVATE() 23
+#elif (defined(__cplusplus) && __cplusplus >= 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
+#pragma message "oops The value of STLAB_CPP_VERSION: 20"
+#define STLAB_CPP_VERSION_PRIVATE() 20
+#elif (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#pragma message "oops The value of STLAB_CPP_VERSION: 17"
 #define STLAB_CPP_VERSION_PRIVATE() 17
-#elif _MSVC_LANG == 202002L
-#define STLAB_CPP_VERSION_PRIVATE() 20
-#else
-#pragma message("Unknown version of C++, assuming C++20.")
-#define STLAB_CPP_VERSION_PRIVATE() 20
-#endif
-
-#endif
-
-#if !defined(STLAB_CPP_VERSION_PRIVATE)
-#if __cplusplus == 201103L
-#define STLAB_CPP_VERSION_PRIVATE() 11
-#elif __cplusplus == 201402L
+#elif (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
+#pragma message "oops The value of STLAB_CPP_VERSION: 14"
 #define STLAB_CPP_VERSION_PRIVATE() 14
-#elif __cplusplus == 201703L
-#define STLAB_CPP_VERSION_PRIVATE() 17
-#elif __cplusplus == 202002L
-#define STLAB_CPP_VERSION_PRIVATE() 20
 #else
 // #warning Unknown version of C++, assuming C++23.
 #define STLAB_CPP_VERSION_PRIVATE() 23
-#endif
-#endif
+#endif  // (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
 
 // STLAB_NODISCARD macro
 
-#if __cplusplus < 201703L
-#define STLAB_NODISCARD()
-#else
+#if STLAB_CPP_VERSION_AT_LEAST(17)
 #define STLAB_NODISCARD() [[nodiscard]]
+#else
+#define STLAB_NODISCARD()
 #endif
 
 #endif // STLAB_CONFIG_HPP

--- a/include/stlab/config.hpp.in
+++ b/include/stlab/config.hpp.in
@@ -73,16 +73,12 @@
 // "It's set to a higher, unspecified value when the /std:c++latest option is specified."
 // Newer compiler has /std:c++23preview, but we are not using it yet.
 #if (defined(__cplusplus) && __cplusplus >= 202302L) || (defined(_MSVC_LANG) && _MSVC_LANG > 202002L)
-#pragma message "oops The value of STLAB_CPP_VERSION: 23"
 #define STLAB_CPP_VERSION_PRIVATE() 23
 #elif (defined(__cplusplus) && __cplusplus >= 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
-#pragma message "oops The value of STLAB_CPP_VERSION: 20"
 #define STLAB_CPP_VERSION_PRIVATE() 20
 #elif (defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
-#pragma message "oops The value of STLAB_CPP_VERSION: 17"
 #define STLAB_CPP_VERSION_PRIVATE() 17
 #elif (defined(__cplusplus) && __cplusplus >= 201402L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
-#pragma message "oops The value of STLAB_CPP_VERSION: 14"
 #define STLAB_CPP_VERSION_PRIVATE() 14
 #else
 // #warning Unknown version of C++, assuming C++23.


### PR DESCRIPTION
When compiled with MSVS, if a build script doesn't pass `/Zc:__cplusplus` condition as `#if __cplusplus < 201703L` won't work. This PR improves this scenario by using `_MSVC_LANG` that always exists.