### PR TITLE
Fixing include paths for dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ endif()
 
 #
 # The include directory for stlab can be expected to vary between build
-# and installaion. Here we use a CMake generator expression to dispatch
+# and installation. Here we use a CMake generator expression to dispatch
 # on how the configuration under which this library is being consumed.
 #
 target_include_directories(stlab INTERFACE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(stlab PRIVATE pre_exit.cpp concurrency/default_executor.cpp)
-target_include_directories(stlab PRIVATE ${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include)
+target_include_directories(stlab PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include ${PROJECT_BINARY_DIR}/include)
 target_compile_definitions(stlab PRIVATE $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>)
 
 if(BUILD_SHARED_LIBS)


### PR DESCRIPTION
- Fixing CMake to properly handle include paths when the library is built as a dependency.