### PR TITLE
Add noexcept as std::shared_ptr::reset() is noexcept

### DIFF
--- a/include/stlab/concurrency/future.hpp
+++ b/include/stlab/concurrency/future.hpp
@@ -828,7 +828,7 @@ public:
         self._detach(std::move(*this), std::forward<F>(f));
     }
 
-    void reset() { _p.reset(); }
+    void reset() noexcept { _p.reset(); }
 
     [[nodiscard]] auto is_ready() const& -> bool { return _p && _p->is_ready(); }
 
@@ -945,7 +945,7 @@ public:
         self._detach(std::move(*this), std::forward<F>(f));
     }
 
-    void reset() { _p.reset(); }
+    void reset() noexcept { _p.reset(); }
 
     [[nodiscard]] auto is_ready() const& -> bool { return _p && _p->is_ready(); }
 


### PR DESCRIPTION
stlab::future::reset() only calls std::shared_ptr::reset, which is noxecept. thus stlab::future::reset() sjould be noexcept.