### PR TITLE
Fix pre_exit ordering so thread pool teardown always runs last

### DIFF
--- a/src/concurrency/default_executor.cpp
+++ b/src/concurrency/default_executor.cpp
@@ -15,6 +15,8 @@
 #include "stlab/config.hpp"   // for STLAB_TASK_SYSTEM, STLAB_TASK_SYSTEM_L...
 #include "stlab/pre_exit.hpp" // for at_pre_exit
 
+extern "C" void stlab_at_pre_exit_first(stlab::pre_exit_handler f);
+
 namespace stlab {
 inline namespace STLAB_VERSION_NAMESPACE() {
 namespace detail {
@@ -24,7 +26,7 @@ auto group() -> const group_t& {
     // Use an immediately executed lambda to atomically register pre-exit handler
     // and create the dispatch group.
     static group_t g{[] {
-        at_pre_exit([]() noexcept { // <br>
+        stlab_at_pre_exit_first([]() noexcept { // <br>
             dispatch_group_wait(g._group, DISPATCH_TIME_FOREVER);
         });
         return group_t{};
@@ -46,7 +48,7 @@ priority_task_system& pts() {
     // Uses the `nullptr` constructor with an immediate executed lambda to register the task
     // system in a thread safe manner.
     static priority_task_system only_task_system{[] {
-        at_pre_exit([]() noexcept { only_task_system.join(); });
+        stlab_at_pre_exit_first([]() noexcept { only_task_system.join(); });
         return nullptr;
     }()};
     return only_task_system;
@@ -58,7 +60,7 @@ priority_task_system& pts() {
 template <executor_priority P>
 task_system<P>& single_task_system() {
     static task_system<P> _task_system{[] {
-        at_pre_exit([]() noexcept { single_task_system<P>().join(); });
+        stlab_at_pre_exit_first([]() noexcept { single_task_system<P>().join(); });
         return task_system<P>{};
     }()};
     return _task_system;

--- a/src/pre_exit.cpp
+++ b/src/pre_exit.cpp
@@ -32,6 +32,15 @@ struct pre_exit_stack_t {
         _stack.push_back(f);
     }
 
+    /// Push an exit handler to the front so it is popped (executed) last.
+    void push_front(pre_exit_handler f) {
+        lock_t lock{_mutex};
+        assert(
+            !_closed &&
+            "WARNING: Adding pre-exit handler with `at_pre_exit()` after `pre_exit()` completed.");
+        _stack.insert(_stack.begin(), f);
+    }
+
     /// Pop one exit handler, returns `nullptr` and closes stack if empty.
     auto pop() -> pre_exit_handler {
         lock_t lock{_mutex};
@@ -65,6 +74,8 @@ extern "C" void stlab_pre_exit() {
 }
 
 extern "C" void stlab_at_pre_exit(pre_exit_handler f) { pre_exit_stack().push(f); }
+
+extern "C" void stlab_at_pre_exit_first(pre_exit_handler f) { pre_exit_stack().push_front(f); }
 
 } // namespace v2
 } // namespace stlab

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -224,7 +224,7 @@ add_test(
 add_executable(stlab.test.pre_exit_order
   pre_exit_order_test.cpp)
 
-target_link_libraries(stlab.test.pre_exit_order PUBLIC stlab::stlab)
+target_link_libraries(stlab.test.pre_exit_order PUBLIC stlab::testing)
 
 add_test(
   NAME stlab.test.pre_exit_order

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -220,6 +220,20 @@ add_test(
 )
 
 ################################################################################
+
+add_executable(stlab.test.pre_exit_order
+  pre_exit_order_test.cpp)
+
+target_link_libraries(stlab.test.pre_exit_order PUBLIC stlab::stlab)
+
+add_test(
+  NAME stlab.test.pre_exit_order
+  COMMAND stlab.test.pre_exit_order
+)
+
+set_tests_properties(stlab.test.pre_exit_order PROPERTIES TIMEOUT 10)
+
+################################################################################
 #
 # tests are compiled without compiler extensions to ensure the stlab headers
 # are not dependent upon any such extension.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -234,6 +234,18 @@ add_test(
 set_tests_properties(stlab.test.pre_exit_order PROPERTIES TIMEOUT 10)
 
 ################################################################################
+
+add_executable(stlab.test.pre_exit_first
+  pre_exit_first_test.cpp)
+
+target_link_libraries(stlab.test.pre_exit_first PUBLIC stlab::testing)
+
+add_test(
+  NAME stlab.test.pre_exit_first
+  COMMAND stlab.test.pre_exit_first
+)
+
+################################################################################
 #
 # tests are compiled without compiler extensions to ensure the stlab headers
 # are not dependent upon any such extension.

--- a/test/pre_exit_first_test.cpp
+++ b/test/pre_exit_first_test.cpp
@@ -55,11 +55,11 @@ int main(int argc, char** argv) {
     stlab::pre_exit();
 
     // Verify: 3 runs first, then 1, then 2 (front-inserted) last.
-    REQUIRE(execution_order.size() == 3);
-    CHECK(execution_order[0] == 3);
-    CHECK(execution_order[1] == 1);
-    CHECK(execution_order[2] == 2);
+    // CHECK/REQUIRE cannot be used outside a test case, so validate via return code.
+    if (execution_order.size() != 3) return 1;
+    if (execution_order[0] != 3) return 1;
+    if (execution_order[1] != 1) return 1;
+    if (execution_order[2] != 2) return 1;
 
-    return res || execution_order.size() != 3 || execution_order[0] != 3 ||
-           execution_order[1] != 1 || execution_order[2] != 2;
+    return res;
 }

--- a/test/pre_exit_first_test.cpp
+++ b/test/pre_exit_first_test.cpp
@@ -1,0 +1,65 @@
+/*
+    Copyright 2026 Adobe
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/*
+    Test: stlab_at_pre_exit_first ordering.
+
+    Validates that handlers registered via stlab_at_pre_exit_first are always executed last
+    (popped last from the stack), regardless of when they are registered relative to normal
+    at_pre_exit handlers. This is the mechanism used to ensure the thread pool teardown
+    always runs after all client handlers.
+*/
+
+#define DOCTEST_CONFIG_IMPLEMENT
+#include <doctest/doctest.h>
+
+#include <vector>
+
+#include <stlab/pre_exit.hpp>
+
+extern "C" void stlab_at_pre_exit_first(stlab::pre_exit_handler f);
+
+namespace {
+
+std::vector<int> execution_order;
+
+void handler_1() noexcept { execution_order.push_back(1); }
+void handler_2() noexcept { execution_order.push_back(2); }
+void handler_3() noexcept { execution_order.push_back(3); }
+
+} // namespace
+
+TEST_CASE("stlab_at_pre_exit_first handlers run after normal handlers") {
+    // Register 1 normally.
+    stlab::at_pre_exit(handler_1);
+
+    // Register 2 at front — should always execute last.
+    stlab_at_pre_exit_first(handler_2);
+
+    // Register 3 normally.
+    stlab::at_pre_exit(handler_3);
+
+    // Stack: [2(front), 1, 3]
+    // Pop order (LIFO): 3, 1, 2
+}
+
+int main(int argc, char** argv) {
+    doctest::Context ctx;
+    ctx.applyCommandLine(argc, argv);
+    int res = ctx.run();
+    if (ctx.shouldExit()) return res;
+
+    stlab::pre_exit();
+
+    // Verify: 3 runs first, then 1, then 2 (front-inserted) last.
+    REQUIRE(execution_order.size() == 3);
+    CHECK(execution_order[0] == 3);
+    CHECK(execution_order[1] == 1);
+    CHECK(execution_order[2] == 2);
+
+    return res || execution_order.size() != 3 || execution_order[0] != 3 ||
+           execution_order[1] != 1 || execution_order[2] != 2;
+}

--- a/test/pre_exit_order_test.cpp
+++ b/test/pre_exit_order_test.cpp
@@ -18,8 +18,10 @@
     so the test passes regardless. It remains valuable as a regression test for all platforms.
 */
 
+#define DOCTEST_CONFIG_IMPLEMENT
+#include <doctest/doctest.h>
+
 #include <atomic>
-#include <cstdlib>
 
 #include <stlab/concurrency/default_executor.hpp>
 #include <stlab/pre_exit.hpp>
@@ -40,7 +42,7 @@ void client_handler() noexcept {
 
 } // namespace
 
-int main() {
+TEST_CASE("pre_exit handler registered before executor init can still use executor") {
     // Register client handler BEFORE any executor use — this places it at index 0.
     stlab::at_pre_exit(client_handler);
 
@@ -49,10 +51,18 @@ int main() {
     stlab::default_executor([&init_done]() noexcept { init_done = true; });
     while (!init_done) {
     }
+}
+
+int main(int argc, char** argv) {
+    doctest::Context ctx;
+    ctx.applyCommandLine(argc, argv);
+    int res = ctx.run();
+    if (ctx.shouldExit()) return res;
 
     // pre_exit() pops from back (LIFO). Without the fix, teardown (index 1) runs
     // before client_handler (index 0), destroying the pool first.
     stlab::pre_exit();
 
-    return client_handler_succeeded ? EXIT_SUCCESS : EXIT_FAILURE;
+    // CHECK cannot be used outside a test case, so validate via return code.
+    return res || !client_handler_succeeded;
 }

--- a/test/pre_exit_order_test.cpp
+++ b/test/pre_exit_order_test.cpp
@@ -1,0 +1,58 @@
+/*
+    Copyright 2026 Adobe
+    Distributed under the Boost Software License, Version 1.0.
+    (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/*
+    Test: pre_exit handler ordering.
+
+    Validates that a client pre_exit handler registered BEFORE the thread pool is initialized
+    can still use the executor during pre_exit(). The thread pool teardown must run after all
+    client handlers.
+
+    On PORTABLE and WINDOWS backends, the teardown calls join() which destroys the pool. If
+    the ordering is wrong, this test hangs and is killed by CTest's TIMEOUT property.
+
+    On libdispatch (macOS), the teardown only waits on the dispatch group — the pool survives —
+    so the test passes regardless. It remains valuable as a regression test for all platforms.
+*/
+
+#include <atomic>
+#include <cstdlib>
+
+#include <stlab/concurrency/default_executor.hpp>
+#include <stlab/pre_exit.hpp>
+
+namespace {
+
+std::atomic<bool> client_handler_succeeded{false};
+
+void client_handler() noexcept {
+    // Schedule work on the executor and spin-wait for completion.
+    // If the thread pool was already torn down, this hangs (PORTABLE/WINDOWS).
+    std::atomic<bool> done{false};
+    stlab::default_executor([&done]() noexcept { done = true; });
+    while (!done) {
+    }
+    client_handler_succeeded = true;
+}
+
+} // namespace
+
+int main() {
+    // Register client handler BEFORE any executor use — this places it at index 0.
+    stlab::at_pre_exit(client_handler);
+
+    // Trigger lazy executor init — registers teardown handler at index 1+.
+    std::atomic<bool> init_done{false};
+    stlab::default_executor([&init_done]() noexcept { init_done = true; });
+    while (!init_done) {
+    }
+
+    // pre_exit() pops from back (LIFO). Without the fix, teardown (index 1) runs
+    // before client_handler (index 0), destroying the pool first.
+    stlab::pre_exit();
+
+    return client_handler_succeeded ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Problem Description
- Client code registered via `at_pre_exit()` before the executor is initialized ends up at a lower index in the pre_exit stack than the thread pool teardown handler. Since `pre_exit()` pops in LIFO order, the teardown runs first, leaving the client handler unable to use the executor. This causes hangs on PORTABLE and WINDOWS backends where teardown destroys the pool. I ran into this issue when refactoring some code to use stlab::serial_queue.

## Solution
Add `stlab_at_pre_exit_first`, an internal function that inserts handlers at the front of the stack (index 0) so they are always popped last. The thread pool teardown on all three backends (libdispatch, portable, windows) now uses this function. 

## Automated Tests
- New unit test (`pre_exit_first_test`) verifies that handlers registered via `stlab_at_pre_exit_first` always execute last, regardless of registration order
- New integration test (`pre_exit_order_test`) verifies a client handler registered before executor init can still use the executor during `pre_exit()`
- Full test suite passes (14/14)