### PR TITLE
Implement generic `resume_on` support for awaitables in `future<>`

### DIFF
--- a/.github/workflows/stlab.yml
+++ b/.github/workflows/stlab.yml
@@ -78,8 +78,10 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/cmake/Platform/Emscripten-STLab.cmake
 
       - name: Setup MSVC
-        if: ${{ startsWith(matrix.config.os, 'windows') }}
-        uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ startsWith(matrix.config.os, 'windows') }}  
+        uses: TheMrMilchmann/setup-msvc-dev@v4
+        with:
+          arch: x64
 
       - name: Configure // Windows
         if: ${{ startsWith(matrix.config.os, 'windows') }}

--- a/include/stlab/concurrency/future.hpp
+++ b/include/stlab/concurrency/future.hpp
@@ -1953,6 +1953,98 @@ namespace stlab {
 inline namespace STLAB_VERSION_NAMESPACE() {
 namespace detail {
 
+// --- Generic awaitable support for resume_on(executor, any_awaitable) ---
+template <class A, class = void>
+struct has_member_co_await : std::false_type {};
+template <class A>
+struct has_member_co_await<A, std::void_t<decltype(std::declval<A>().operator co_await())>>
+    : std::true_type {};
+
+template <class A>
+auto get_awaiter(A&& a) {
+    if constexpr (has_member_co_await<A>::value) {
+        return std::forward<A>(a).operator co_await();
+    } else {
+        return operator co_await(std::forward<A>(a));
+    }
+}
+
+template <class A>
+using awaiter_t = decltype(get_awaiter(std::declval<A&>()));
+
+template <class A>
+using await_result_t = decltype(std::declval<awaiter_t<A>>().await_resume());
+
+template <class A>
+using await_result_storage_t = void_to_monostate_t<await_result_t<A>>;
+
+// Fire-and-forget return type for the proxy coroutine. No handle is retained after launch;
+// the proxy owns itself and self-destroys at final_suspend (suspend_never).
+struct proxy_fire_and_forget {
+    struct promise_type {
+        proxy_fire_and_forget get_return_object() { return {}; }
+        std::suspend_never initial_suspend() { return {}; }
+        std::suspend_never final_suspend() noexcept { return {}; }
+        void return_void() {}
+        void unhandled_exception() { std::terminate(); }
+    };
+};
+
+/// Proxy coroutine: runs co_await on the inner awaitable then invokes executor(resume_cb).
+/// Fire-and-forget: self-destroys at completion (final_suspend is suspend_never).
+template <class A, class E, class F>
+proxy_fire_and_forget resume_on_proxy_coro(E executor,
+                                           F resume_cb,
+                                           A awaitable,
+                                           std::optional<await_result_storage_t<A>>* result_ptr,
+                                           std::exception_ptr* exception_ptr) {
+    try {
+        if constexpr (std::is_void_v<await_result_t<A>>) {
+            co_await std::move(awaitable);
+            result_ptr->emplace(std::monostate{});
+        } else {
+            result_ptr->emplace(co_await std::move(awaitable));
+        }
+    } catch (...) {
+        if (exception_ptr) *exception_ptr = std::current_exception();
+    }
+    executor(std::move(resume_cb));
+}
+
+/// Controlled-path proxy coroutine: writes to awaiter storage only while weak_state is alive.
+template <class A, class E, class F, class WeakPtr>
+proxy_fire_and_forget resume_on_proxy_coro_controlled(
+    E executor,
+    F resume_cb,
+    A awaitable,
+    WeakPtr weak,
+    std::optional<await_result_storage_t<A>>* result_ptr,
+    std::exception_ptr* exception_ptr) {
+    // proceed with co_await; if weak_state is destroyed during suspension, the proxy is
+    // responsible for not writing to awaiter storage and not invoking the resume callback.
+    try {
+        if constexpr (std::is_void_v<await_result_t<A>>) {
+            co_await std::move(awaitable);
+            if (auto keepalive = weak.lock()) {
+                (void)keepalive;
+                result_ptr->emplace(std::monostate{});
+            }
+        } else {
+            auto tmp = co_await std::move(awaitable);
+            if (auto keepalive = weak.lock()) {
+                (void)keepalive;
+                result_ptr->emplace(std::move(tmp));
+            }
+        }
+    } catch (...) {
+        if (auto keepalive = weak.lock()) {
+            (void)keepalive;
+            if (exception_ptr) *exception_ptr = std::current_exception();
+        }
+    }
+    executor(std::move(resume_cb));
+}
+
 template <class... Args>
 struct final_awaiter {
     bool await_ready() noexcept { return false; }
@@ -2027,7 +2119,7 @@ struct resume_on_executor_awaiter_with_control {
     E _executor;
     WeakPtr _weak;
 
-    bool await_ready() const noexcept { return false; }
+    [[nodiscard]] bool await_ready() const noexcept { return false; }
     void await_resume() noexcept {}
     void await_suspend(std::coroutine_handle<> ch) {
         assert(_weak.lock() && "await_suspend: weak_state is gone");
@@ -2039,6 +2131,101 @@ struct resume_on_executor_awaiter_with_control {
     }
 };
 
+/// Awaitable that suspends and resumes the coroutine on the given executor when any awaitable
+/// completes. When the inner is ready without suspending, still resumes on the executor.
+template <class E, class A>
+struct resume_on_any_awaiter {
+    E _executor;
+    A _awaitable;
+    std::optional<await_result_storage_t<A>> _result;
+    std::exception_ptr _exception;
+
+    bool await_ready() const noexcept { return false; }
+
+    await_result_t<A> await_resume() {
+        if (_exception) std::rethrow_exception(_exception);
+        if constexpr (std::is_void_v<await_result_t<A>>) {
+            return;
+        } else {
+            return std::move(*_result);
+        }
+    }
+
+    void await_suspend(std::coroutine_handle<> ch) {
+        auto inner = get_awaiter(_awaitable);
+        if (inner.await_ready()) {
+            try {
+                if constexpr (std::is_void_v<await_result_t<A>>) {
+                    inner.await_resume();
+                    _result.emplace(std::monostate{});
+                } else {
+                    _result.emplace(inner.await_resume());
+                }
+            } catch (...) {
+                _exception = std::current_exception();
+            }
+            std::move(_executor)([ch]() noexcept { ch.resume(); });
+            return;
+        }
+        resume_on_proxy_coro(
+            std::move(_executor), [ch]() noexcept { ch.resume(); }, std::move(_awaitable), &_result,
+            &_exception);
+    }
+};
+
+/// resume_on_any_awaiter with weak_ptr check for use from coroutines (via await_transform).
+/// Keeps cancellation: when the returned future is destroyed while suspended, the coroutine
+/// is not resumed.
+template <class E, class A, class WeakPtr>
+struct resume_on_any_awaiter_with_control {
+    E _executor;
+    A _awaitable;
+    WeakPtr _weak;
+    std::optional<await_result_storage_t<A>> _result;
+    std::exception_ptr _exception;
+
+    bool await_ready() const noexcept { return false; }
+
+    await_result_t<A> await_resume() {
+        if (_exception) std::rethrow_exception(_exception);
+        if constexpr (std::is_void_v<await_result_t<A>>) {
+            return;
+        } else {
+            return std::move(*_result);
+        }
+    }
+
+    void await_suspend(std::coroutine_handle<> ch) {
+        assert(_weak.lock() && "await_suspend: weak_state is gone");
+        _weak.lock()->_co_handle = ch.address();
+        auto inner = get_awaiter(_awaitable);
+        if (inner.await_ready()) {
+            try {
+                if constexpr (std::is_void_v<await_result_t<A>>) {
+                    inner.await_resume();
+                    _result.emplace(std::monostate{});
+                } else {
+                    _result.emplace(inner.await_resume());
+                }
+            } catch (...) {
+                _exception = std::current_exception();
+            }
+            std::move(_executor)([weak = _weak]() noexcept {
+                if (auto state = weak.lock())
+                    std::coroutine_handle<>::from_address(state->_co_handle).resume();
+            });
+            return;
+        }
+        resume_on_proxy_coro_controlled(
+            std::move(_executor),
+            [weak = _weak]() noexcept {
+                if (auto state = weak.lock())
+                    std::coroutine_handle<>::from_address(state->_co_handle).resume();
+            },
+            std::move(_awaitable), _weak, &_result, &_exception);
+    }
+};
+
 } // namespace detail
 
 /// When the future completes, the current coroutine is resumed on `executor`; result/exception
@@ -2046,6 +2233,15 @@ struct resume_on_executor_awaiter_with_control {
 template <class E, class R>
 auto resume_on(E&& executor, future<R>&& f) -> detail::resume_on_awaiter<R, std::decay_t<E>> {
     return detail::resume_on_awaiter{std::forward<E>(executor), std::move(f)};
+}
+
+/// When the awaitable completes, the current coroutine is resumed on `executor`; works with any
+/// awaitable (not just future). Result/exception semantics are the same as `co_await std::move(a)`.
+template <class E, class A>
+auto resume_on(E&& executor, A&& awaitable)
+    -> detail::resume_on_any_awaiter<std::decay_t<E>, std::decay_t<A>> {
+    return detail::resume_on_any_awaiter<std::decay_t<E>, std::decay_t<A>>{
+        std::forward<E>(executor), std::forward<A>(awaitable), {}, {}};
 }
 
 /// Suspends and resumes the coroutine on the given executor. If used within a coroutine returning a
@@ -2071,7 +2267,7 @@ auto resume_on(E&& executor) -> detail::resume_on_executor_awaiter<std::decay_t<
 /**************************************************************************************************/
 
 template <class T, class... Args>
-struct std::coroutine_traits<stlab::future<T>, Args...> {
+struct std::coroutine_traits<stlab::future<T>, Args...> { // NOLINT(cert-dcl58-cpp)
     struct promise_type {
         stlab::packaged_task<std::variant<T, std::exception_ptr>> _promise;
 
@@ -2126,6 +2322,13 @@ struct std::coroutine_traits<stlab::future<T>, Args...> {
                 E, decltype(stlab::detail::weak_state(_promise))>{
                 std::move(a._executor), stlab::detail::weak_state(_promise)};
         }
+        template <class E, class A>
+        auto await_transform(stlab::detail::resume_on_any_awaiter<E, A> a) {
+            return stlab::detail::resume_on_any_awaiter_with_control<
+                E, A, decltype(stlab::detail::weak_state(_promise))>{
+                std::move(a._executor), std::move(a._awaitable),
+                stlab::detail::weak_state(_promise), std::move(a._result), std::move(a._exception)};
+        }
         template <class U>
         U&& await_transform(U&& u) {
             if (auto state = stlab::detail::weak_state(_promise).lock())
@@ -2178,6 +2381,13 @@ struct std::coroutine_traits<stlab::future<void>, Args...> {
             return stlab::detail::resume_on_executor_awaiter_with_control<
                 E, decltype(stlab::detail::weak_state(_promise))>{
                 std::move(a._executor), stlab::detail::weak_state(_promise)};
+        }
+        template <class E, class A>
+        auto await_transform(stlab::detail::resume_on_any_awaiter<E, A> a) {
+            return stlab::detail::resume_on_any_awaiter_with_control<
+                E, A, decltype(stlab::detail::weak_state(_promise))>{
+                std::move(a._executor), std::move(a._awaitable),
+                stlab::detail::weak_state(_promise), std::move(a._result), std::move(a._exception)};
         }
         template <class U>
         U&& await_transform(U&& u) {

--- a/include/stlab/concurrency/future.hpp
+++ b/include/stlab/concurrency/future.hpp
@@ -2000,20 +2000,22 @@ struct proxy_fire_and_forget {
     };
 };
 
-/// Proxy coroutine: runs co_await on the inner awaitable then invokes executor(resume_cb).
-/// Fire-and-forget: self-destroys at completion (final_suspend is suspend_never).
-template <class A, class E, class F>
+/// Proxy coroutine: runs co_await on the inner awaiter (already produced from the awaitable via
+/// get_awaiter) then invokes executor(resume_cb). Fire-and-forget: self-destroys at completion
+/// (final_suspend is suspend_never). Inner must be the awaiter from a single get_awaiter(awaitable)
+/// so operator co_await() is not invoked twice on the same awaitable.
+template <class A, class Inner, class E, class F>
 proxy_fire_and_forget resume_on_proxy_coro(E executor,
                                            F resume_cb,
-                                           A awaitable,
+                                           Inner inner,
                                            std::optional<await_result_storage_t<A>>* result_ptr,
                                            std::exception_ptr* exception_ptr) {
     try {
         if constexpr (std::is_void_v<await_result_t<A>>) {
-            co_await std::move(awaitable);
+            co_await std::move(inner);
             result_ptr->emplace(std::monostate{});
         } else {
-            result_ptr->emplace(co_await std::move(awaitable));
+            result_ptr->emplace(co_await std::move(inner));
         }
     } catch (...) {
         if (exception_ptr) *exception_ptr = std::current_exception();
@@ -2022,11 +2024,11 @@ proxy_fire_and_forget resume_on_proxy_coro(E executor,
 }
 
 /// Controlled-path proxy coroutine: writes to awaiter storage only while weak_state is alive.
-template <class A, class E, class F, class WeakPtr>
+template <class A, class Inner, class E, class F, class WeakPtr>
 proxy_fire_and_forget resume_on_proxy_coro_controlled(
     E executor,
     F resume_cb,
-    A awaitable,
+    Inner inner,
     WeakPtr weak,
     std::optional<await_result_storage_t<A>>* result_ptr,
     std::exception_ptr* exception_ptr) {
@@ -2034,13 +2036,13 @@ proxy_fire_and_forget resume_on_proxy_coro_controlled(
     // responsible for not writing to awaiter storage and not invoking the resume callback.
     try {
         if constexpr (std::is_void_v<await_result_t<A>>) {
-            co_await std::move(awaitable);
+            co_await std::move(inner);
             if (auto keepalive = weak.lock()) {
                 (void)keepalive;
                 result_ptr->emplace(std::monostate{});
             }
         } else {
-            auto tmp = co_await std::move(awaitable);
+            auto tmp = co_await std::move(inner);
             if (auto keepalive = weak.lock()) {
                 (void)keepalive;
                 result_ptr->emplace(std::move(tmp));
@@ -2162,7 +2164,7 @@ struct resume_on_any_awaiter {
     }
 
     void await_suspend(std::coroutine_handle<> ch) {
-        auto inner = get_awaiter(_awaitable);
+        auto inner = get_awaiter(std::move(_awaitable));
         if (inner.await_ready()) {
             try {
                 if constexpr (std::is_void_v<await_result_t<A>>) {
@@ -2177,8 +2179,8 @@ struct resume_on_any_awaiter {
             std::move(_executor)([ch]() noexcept { ch.resume(); });
             return;
         }
-        resume_on_proxy_coro(
-            std::move(_executor), [ch]() noexcept { ch.resume(); }, std::move(_awaitable), &_result,
+        resume_on_proxy_coro<std::decay_t<A>>(
+            std::move(_executor), [ch]() noexcept { ch.resume(); }, std::move(inner), &_result,
             &_exception);
     }
 };
@@ -2208,7 +2210,7 @@ struct resume_on_any_awaiter_with_control {
     void await_suspend(std::coroutine_handle<> ch) {
         assert(_weak.lock() && "await_suspend: weak_state is gone");
         _weak.lock()->_co_handle = ch.address();
-        auto inner = get_awaiter(_awaitable);
+        auto inner = get_awaiter(std::move(_awaitable));
         if (inner.await_ready()) {
             try {
                 if constexpr (std::is_void_v<await_result_t<A>>) {
@@ -2226,13 +2228,13 @@ struct resume_on_any_awaiter_with_control {
             });
             return;
         }
-        resume_on_proxy_coro_controlled(
+        resume_on_proxy_coro_controlled<std::decay_t<A>>(
             std::move(_executor),
             [weak = _weak]() noexcept {
                 if (auto state = weak.lock())
                     std::coroutine_handle<>::from_address(state->_co_handle).resume();
             },
-            std::move(_awaitable), _weak, &_result, &_exception);
+            std::move(inner), _weak, &_result, &_exception);
     }
 };
 

--- a/include/stlab/concurrency/future.hpp
+++ b/include/stlab/concurrency/future.hpp
@@ -1954,18 +1954,28 @@ inline namespace STLAB_VERSION_NAMESPACE() {
 namespace detail {
 
 // --- Generic awaitable support for resume_on(executor, any_awaitable) ---
+// C++ coroutine protocol: awaitable is (1) has member operator co_await, (2) has free
+// operator co_await, or (3) is directly an awaiter (await_ready/await_suspend/await_resume).
 template <class A, class = void>
 struct has_member_co_await : std::false_type {};
 template <class A>
 struct has_member_co_await<A, std::void_t<decltype(std::declval<A>().operator co_await())>>
     : std::true_type {};
 
+template <class A, class = void>
+struct has_free_co_await : std::false_type {};
+template <class A>
+struct has_free_co_await<A, std::void_t<decltype(operator co_await(std::declval<A>()))>>
+    : std::true_type {};
+
 template <class A>
 auto get_awaiter(A&& a) {
     if constexpr (has_member_co_await<A>::value) {
         return std::forward<A>(a).operator co_await();
-    } else {
+    } else if constexpr (has_free_co_await<A>::value) {
         return operator co_await(std::forward<A>(a));
+    } else {
+        return std::forward<A>(a);  // direct awaiter (e.g. std::suspend_always)
     }
 }
 

--- a/include/stlab/concurrency/future.hpp
+++ b/include/stlab/concurrency/future.hpp
@@ -2034,27 +2034,31 @@ proxy_fire_and_forget resume_on_proxy_coro_controlled(
     std::exception_ptr* exception_ptr) {
     // proceed with co_await; if weak_state is destroyed during suspension, the proxy is
     // responsible for not writing to awaiter storage and not invoking the resume callback.
+    bool was_alive = false;
     try {
         if constexpr (std::is_void_v<await_result_t<A>>) {
             co_await std::move(inner);
             if (auto keepalive = weak.lock()) {
                 (void)keepalive;
                 result_ptr->emplace(std::monostate{});
+                was_alive = true;
             }
         } else {
             auto tmp = co_await std::move(inner);
             if (auto keepalive = weak.lock()) {
                 (void)keepalive;
                 result_ptr->emplace(std::move(tmp));
+                was_alive = true;
             }
         }
     } catch (...) {
         if (auto keepalive = weak.lock()) {
             (void)keepalive;
             if (exception_ptr) *exception_ptr = std::current_exception();
+            was_alive = true;
         }
     }
-    executor(std::move(resume_cb));
+    if (was_alive) executor(std::move(resume_cb));
 }
 
 template <class... Args>

--- a/include/stlab/concurrency/future.hpp
+++ b/include/stlab/concurrency/future.hpp
@@ -1975,7 +1975,7 @@ auto get_awaiter(A&& a) {
     } else if constexpr (has_free_co_await<A>::value) {
         return operator co_await(std::forward<A>(a));
     } else {
-        return std::forward<A>(a);  // direct awaiter (e.g. std::suspend_always)
+        return std::forward<A>(a); // direct awaiter (e.g. std::suspend_always)
     }
 }
 
@@ -2242,6 +2242,30 @@ struct resume_on_any_awaiter_with_control {
     }
 };
 
+/// Operand for `co_await cancelable(awaitable)` and `co_await cancelable()` (no arguments). Only
+/// `stlab::future` promise types define `await_transform` for it (otherwise `co_await` is
+/// ill-formed). The `void` specialization is produced by `cancelable()`; other `A` wrap an awaitable.
+template <class A>
+struct cancelable_requires_stlab_future_coroutine {
+    A _awaitable;
+};
+
+template <>
+struct cancelable_requires_stlab_future_coroutine<void> {};
+
+/// If `weak_state` is still valid (the shared state exists — at least one `future` still references
+/// it), `await_ready()` is true: no suspension; execution continues past the checkpoint. If the
+/// weak pointer has expired (no `future` still references the shared state), the coroutine suspends
+/// and `await_suspend` destroys it (`ch.destroy()`); there is no scheduled resumption.
+template <class WeakPtr>
+struct cancelable_unique_checkpoint_awaiter {
+    WeakPtr _weak;
+
+    [[nodiscard]] bool await_ready() const noexcept { return !_weak.expired(); }
+    void await_resume() noexcept {}
+    void await_suspend(std::coroutine_handle<> ch) { ch.destroy(); }
+};
+
 } // namespace detail
 
 /// When the future completes, the current coroutine is resumed on `executor`; result/exception
@@ -2267,6 +2291,34 @@ auto resume_on(E&& executor) -> detail::resume_on_executor_awaiter<std::decay_t<
     return detail::resume_on_executor_awaiter<std::decay_t<E>>{std::forward<E>(executor)};
 }
 
+/// Same semantics as `co_await resume_on(immediate_executor, awaitable)` inside a coroutine
+/// returning `stlab::future`, but only valid there (cancellation via `weak_state`; invalid outside
+/// stlab future coroutines—see `cancelable_requires_stlab_future_coroutine`).
+template <class A, std::enable_if_t<!detail::is_future_v<std::decay_t<A>>, int> = 0>
+auto cancelable(A&& awaitable)
+    -> detail::cancelable_requires_stlab_future_coroutine<std::decay_t<A>> {
+    return {std::forward<A>(awaitable)};
+}
+
+template <class R>
+auto cancelable(future<R>&) // Use co_await std::move(f); it is already cancelable.
+    -> future<R> = delete;
+
+template <class R>
+auto cancelable(future<R>&&) // Use co_await std::move(f); it is already cancelable.
+    -> future<R> = delete;
+
+template <class R>
+auto cancelable(const future<R>&) // Use co_await std::move(f); it is already cancelable.
+    -> future<R> = delete;
+
+/// Checkpoint: if no `future` still references the shared state (`weak_state` expired), the
+/// coroutine is destroyed when the checkpoint is reached. If at least one `future` still exists,
+/// execution continues without suspending.
+[[nodiscard]] inline auto cancelable() -> detail::cancelable_requires_stlab_future_coroutine<void> {
+    return {};
+}
+
 } // namespace STLAB_VERSION_NAMESPACE()
 } // namespace stlab
 
@@ -2280,6 +2332,9 @@ auto resume_on(E&& executor) -> detail::resume_on_executor_awaiter<std::decay_t<
 // suspended on a future we store the handle in _co_handle so we can resume via weak_state. For
 // non-future awaitables we clear _co_handle before suspending (give up ownership for that suspend).
 // initial_suspend is suspend_never so we never own before the first suspend.
+// `co_await cancelable()` with no arguments: if weak_state is expired (last future already
+// released), await_suspend destroys the coroutine handle directly — not via _co_handle. If the weak
+// is still valid, await_ready avoids suspension so execution continues.
 /**************************************************************************************************/
 
 template <class T, class... Args>
@@ -2345,6 +2400,20 @@ struct std::coroutine_traits<stlab::future<T>, Args...> { // NOLINT(cert-dcl58-c
                 std::move(a._executor), std::move(a._awaitable),
                 stlab::detail::weak_state(_promise), std::move(a._result), std::move(a._exception)};
         }
+        auto await_transform(stlab::detail::cancelable_requires_stlab_future_coroutine<void>) {
+            return stlab::detail::cancelable_unique_checkpoint_awaiter<
+                decltype(stlab::detail::weak_state(_promise))>{stlab::detail::weak_state(_promise)};
+        }
+        template <class A, std::enable_if_t<!std::is_void_v<A>, int> = 0>
+        auto await_transform(stlab::detail::cancelable_requires_stlab_future_coroutine<A> c) {
+            return stlab::detail::resume_on_any_awaiter_with_control<
+                decltype(stlab::immediate_executor), A,
+                decltype(stlab::detail::weak_state(_promise))>{stlab::immediate_executor,
+                                                               std::move(c._awaitable),
+                                                               stlab::detail::weak_state(_promise),
+                                                               {},
+                                                               {}};
+        }
         template <class U>
         U&& await_transform(U&& u) {
             if (auto state = stlab::detail::weak_state(_promise).lock())
@@ -2404,6 +2473,20 @@ struct std::coroutine_traits<stlab::future<void>, Args...> {
                 E, A, decltype(stlab::detail::weak_state(_promise))>{
                 std::move(a._executor), std::move(a._awaitable),
                 stlab::detail::weak_state(_promise), std::move(a._result), std::move(a._exception)};
+        }
+        auto await_transform(stlab::detail::cancelable_requires_stlab_future_coroutine<void>) {
+            return stlab::detail::cancelable_unique_checkpoint_awaiter<
+                decltype(stlab::detail::weak_state(_promise))>{stlab::detail::weak_state(_promise)};
+        }
+        template <class A, std::enable_if_t<!std::is_void_v<A>, int> = 0>
+        auto await_transform(stlab::detail::cancelable_requires_stlab_future_coroutine<A> c) {
+            return stlab::detail::resume_on_any_awaiter_with_control<
+                decltype(stlab::immediate_executor), A,
+                decltype(stlab::detail::weak_state(_promise))>{stlab::immediate_executor,
+                                                               std::move(c._awaitable),
+                                                               stlab::detail::weak_state(_promise),
+                                                               {},
+                                                               {}};
         }
         template <class U>
         U&& await_transform(U&& u) {

--- a/test/future_coroutine_tests.cpp
+++ b/test/future_coroutine_tests.cpp
@@ -280,6 +280,22 @@ struct manual_complete_void_awaitable {
     manual_complete_void_awaitable& operator co_await() { return *this; }
 };
 
+// operator co_await() must run once on the suspend path (no probe + proxy double-call).
+inline std::atomic<int> g_co_await_invocation_count{0};
+
+struct co_await_counting_awaitable {
+    struct awaiter {
+        bool await_ready() const noexcept { return false; }
+        void await_suspend(std::coroutine_handle<> h) { g_proxy_handle = h; }
+        int await_resume() { return 99; }
+    };
+    // Unqualified so awaiter_t<A> (via get_awaiter(declval<A&>())) matches stlab's traits.
+    awaiter operator co_await() {
+        ++g_co_await_invocation_count;
+        return {};
+    }
+};
+
 struct detached_test_coro {
     struct promise_type {
         detached_test_coro get_return_object() { return {}; }
@@ -291,6 +307,26 @@ struct detached_test_coro {
 };
 
 } // namespace
+
+TEST_CASE("resume_on_generic_single_co_await_on_suspend_path") {
+    test::cooperative_executor coop;
+    g_proxy_handle = nullptr;
+    g_co_await_invocation_count.store(0);
+
+    auto coro = [&]() -> future<int> {
+        int x = co_await resume_on(coop.executor(), co_await_counting_awaitable{});
+        co_return x;
+    };
+    auto f = coro();
+
+    REQUIRE(g_proxy_handle);
+    REQUIRE(g_co_await_invocation_count.load() == 1);
+    g_proxy_handle.resume();
+    coop.execute_all();
+
+    REQUIRE(await(std::move(f)) == 99);
+    REQUIRE(g_co_await_invocation_count.load() == 1);
+}
 
 TEST_CASE("resume_on_generic_resumes_on_executor") {
     test::cooperative_executor coop;

--- a/test/future_coroutine_tests.cpp
+++ b/test/future_coroutine_tests.cpp
@@ -8,6 +8,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <string>
 #include <thread>
 #include <utility>
@@ -195,7 +196,7 @@ TEST_CASE("generic_await_escape_then_resume_after_future_reset") {
 }
 
 TEST_CASE("throwing_operation_in_coawait_future") {
-    auto f = []() -> future<int> {
+    auto coro = []() -> future<int> {
         try {
             co_await make_exceptional_future<void>(
                 std::make_exception_ptr(test_exception("failure")), default_executor);
@@ -203,13 +204,14 @@ TEST_CASE("throwing_operation_in_coawait_future") {
             co_return 1;
         }
         co_return 0;
-    }();
+    };
+    auto f = coro();
     REQUIRE(std::move(f).get_ready() == 1);
 }
 
 TEST_CASE("resume_on") {
     string sequence;
-    auto f = [&]() -> future<int> {
+    auto coro = [&]() -> future<int> {
         sequence += "start;";
         co_await resume_on([&](auto&& task) {
             sequence += "resume;";
@@ -217,7 +219,8 @@ TEST_CASE("resume_on") {
         });
         sequence += "finish;";
         co_return 42;
-    }();
+    };
+    auto f = coro();
     REQUIRE(f.get_ready() == 42);
     REQUIRE(sequence == "start;resume;finish;");
 }
@@ -225,12 +228,12 @@ TEST_CASE("resume_on") {
 TEST_CASE("resume_on_with_cancel") {
     test::cooperative_executor coop;
     string sequence;
-    (void)[&]()->future<void> {
+    auto coro = [&]() -> future<void> {
         sequence += "start;";
         co_await resume_on(coop.executor());
         sequence += "finish;";
-    }
-    (); // drop the result to cancel
+    };
+    (void)coro(); // drop the result to cancel
     coop.execute_all();
     REQUIRE(sequence == "start;");
 }
@@ -293,10 +296,11 @@ TEST_CASE("resume_on_generic_resumes_on_executor") {
     test::cooperative_executor coop;
     g_proxy_handle = nullptr;
 
-    auto f = [&]() -> future<int> {
+    auto coro = [&]() -> future<int> {
         int x = co_await resume_on(coop.executor(), manual_complete_awaitable{});
         co_return x + 35;
-    }();
+    };
+    auto f = coro();
 
     REQUIRE(g_proxy_handle);
     g_proxy_handle.resume();
@@ -312,12 +316,13 @@ TEST_CASE("resume_on_generic_ready_awaitable_resumes_on_executor") {
         task();
     };
 
-    auto f = [&]() -> future<int> {
+    auto coro = [&]() -> future<int> {
         sequence += "start;";
         int x = co_await resume_on(exec, ready_value_awaitable{99});
         sequence += "done;";
         co_return x;
-    }();
+    };
+    auto f = coro();
 
     REQUIRE(sequence == "start;exec;done;");
     REQUIRE(f.get_ready() == 99);
@@ -330,7 +335,7 @@ TEST_CASE("resume_on_generic_propagates_exception") {
         task();
     };
 
-    auto f = [&]() -> future<int> {
+    auto coro = [&]() -> future<int> {
         sequence += "start;";
         try {
             (void)co_await resume_on(exec, throwing_awaitable{});
@@ -340,7 +345,8 @@ TEST_CASE("resume_on_generic_propagates_exception") {
             co_return 1;
         }
         co_return 0;
-    }();
+    };
+    auto f = coro();
 
     REQUIRE(sequence == "start;exec;catch;");
     REQUIRE(f.get_ready() == 1);
@@ -351,7 +357,9 @@ TEST_CASE("resume_on_generic_suspend_propagates_exception") {
     string sequence;
     g_proxy_handle = nullptr;
 
-    auto f = [&]() -> future<int> {
+    // Named lambda so the closure outlives the first suspend (avoids ASan stack-use-after-scope
+    // from coroutine frame holding __closure that pointed at an IIFE temporary).
+    auto coro = [&]() -> future<int> {
         sequence += "start;";
         try {
             (void)co_await resume_on(coop.executor(), suspend_throwing_awaitable{});
@@ -361,7 +369,8 @@ TEST_CASE("resume_on_generic_suspend_propagates_exception") {
             co_return 1;
         }
         co_return 0;
-    }();
+    };
+    auto f = coro();
 
     REQUIRE(sequence == "start;");
     REQUIRE(g_proxy_handle);
@@ -372,17 +381,46 @@ TEST_CASE("resume_on_generic_suspend_propagates_exception") {
     REQUIRE(f.get_ready() == 1);
 }
 
+// Minimal repro variant: no [&] capture for sequence; use shared_ptr so coroutine doesn't hold stack ref.
+TEST_CASE("resume_on_generic_suspend_propagates_exception_no_ref_capture") {
+    test::cooperative_executor coop;
+    auto sequence = std::make_shared<std::string>();
+    g_proxy_handle = nullptr;
+
+    auto coro = [coop_ptr = &coop, sequence]() -> future<int> {
+        *sequence += "start;";
+        try {
+            (void)co_await resume_on(coop_ptr->executor(), suspend_throwing_awaitable{});
+        } catch (const test_exception& e) {
+            *sequence += "catch;";
+            REQUIRE(string(e.what()) == "generic resume_on suspend throw");
+            co_return 1;
+        }
+        co_return 0;
+    };
+    auto f = coro();
+
+    REQUIRE(*sequence == "start;");
+    REQUIRE(g_proxy_handle);
+    g_proxy_handle.resume();
+    coop.execute_all();
+
+    REQUIRE(*sequence == "start;catch;");
+    REQUIRE(f.get_ready() == 1);
+}
+
 TEST_CASE("resume_on_generic_void_awaitable_suspend_path") {
     test::cooperative_executor coop;
     string sequence;
     g_proxy_handle = nullptr;
 
-    auto f = [&]() -> future<int> {
+    auto coro = [&]() -> future<int> {
         sequence += "start;";
         co_await resume_on(coop.executor(), manual_complete_void_awaitable{});
         sequence += "done;";
         co_return 11;
-    }();
+    };
+    auto f = coro();
 
     REQUIRE(sequence == "start;");
     REQUIRE(g_proxy_handle);
@@ -437,11 +475,12 @@ TEST_CASE("resume_on_generic_with_cancel") {
     test::cooperative_executor coop;
     string sequence;
 
-    auto f = [&]() -> future<void> {
+    auto coro = [&]() -> future<void> {
         sequence += "start;";
         co_await resume_on(coop.executor(), manual_complete_awaitable{});
         sequence += "finish;";
-    }();
+    };
+    auto f = coro();
 
     REQUIRE(sequence == "start;");
     f.reset();

--- a/test/future_coroutine_tests.cpp
+++ b/test/future_coroutine_tests.cpp
@@ -328,6 +328,27 @@ TEST_CASE("resume_on_generic_ready_awaitable_resumes_on_executor") {
     REQUIRE(f.get_ready() == 99);
 }
 
+// std::suspend_never is a direct awaiter (no operator co_await); resume_on must handle it.
+// We use suspend_never (not suspend_always) so await_ready() is true and we take the
+// immediate-completion path; suspend_always would suspend the proxy with nothing to resume it.
+TEST_CASE("resume_on_generic_direct_awaiter_resumes_on_executor") {
+    string sequence;
+    auto exec = [&](auto&& task) {
+        sequence += "exec;";
+        task();
+    };
+
+    auto coro = [&]() -> future<void> {
+        sequence += "start;";
+        co_await resume_on(exec, std::suspend_never{});
+        sequence += "done;";
+    };
+    auto f = coro();
+
+    REQUIRE(sequence == "start;exec;done;");
+    (void)await(std::move(f));
+}
+
 TEST_CASE("resume_on_generic_propagates_exception") {
     string sequence;
     auto exec = [&](auto&& task) {

--- a/test/future_coroutine_tests.cpp
+++ b/test/future_coroutine_tests.cpp
@@ -234,3 +234,218 @@ TEST_CASE("resume_on_with_cancel") {
     coop.execute_all();
     REQUIRE(sequence == "start;");
 }
+
+// --- Generic resume_on(executor, any_awaitable) tests ---
+
+namespace {
+
+std::coroutine_handle<> g_proxy_handle;
+
+struct manual_complete_awaitable {
+    bool await_ready() const { return false; }
+    void await_suspend(std::coroutine_handle<> ch) { g_proxy_handle = ch; }
+    int await_resume() { return 7; }
+    manual_complete_awaitable& operator co_await() { return *this; }
+};
+
+struct ready_value_awaitable {
+    int value;
+    bool await_ready() const { return true; }
+    void await_suspend(std::coroutine_handle<>) {}
+    int await_resume() { return value; }
+    ready_value_awaitable& operator co_await() { return *this; }
+};
+
+struct throwing_awaitable {
+    bool await_ready() const { return true; }
+    void await_suspend(std::coroutine_handle<>) {}
+    int await_resume() { throw test_exception("generic resume_on throw"); }
+    throwing_awaitable& operator co_await() { return *this; }
+};
+
+struct suspend_throwing_awaitable {
+    bool await_ready() const { return false; }
+    void await_suspend(std::coroutine_handle<> ch) { g_proxy_handle = ch; }
+    int await_resume() { throw test_exception("generic resume_on suspend throw"); }
+    suspend_throwing_awaitable& operator co_await() { return *this; }
+};
+
+struct manual_complete_void_awaitable {
+    bool await_ready() const { return false; }
+    void await_suspend(std::coroutine_handle<> ch) { g_proxy_handle = ch; }
+    void await_resume() {}
+    manual_complete_void_awaitable& operator co_await() { return *this; }
+};
+
+struct detached_test_coro {
+    struct promise_type {
+        detached_test_coro get_return_object() { return {}; }
+        std::suspend_never initial_suspend() noexcept { return {}; }
+        std::suspend_never final_suspend() noexcept { return {}; }
+        void return_void() noexcept {}
+        void unhandled_exception() { std::terminate(); }
+    };
+};
+
+} // namespace
+
+TEST_CASE("resume_on_generic_resumes_on_executor") {
+    test::cooperative_executor coop;
+    g_proxy_handle = nullptr;
+
+    auto f = [&]() -> future<int> {
+        int x = co_await resume_on(coop.executor(), manual_complete_awaitable{});
+        co_return x + 35;
+    }();
+
+    REQUIRE(g_proxy_handle);
+    g_proxy_handle.resume();
+    coop.execute_all();
+
+    REQUIRE(await(std::move(f)) == 42);
+}
+
+TEST_CASE("resume_on_generic_ready_awaitable_resumes_on_executor") {
+    string sequence;
+    auto exec = [&](auto&& task) {
+        sequence += "exec;";
+        task();
+    };
+
+    auto f = [&]() -> future<int> {
+        sequence += "start;";
+        int x = co_await resume_on(exec, ready_value_awaitable{99});
+        sequence += "done;";
+        co_return x;
+    }();
+
+    REQUIRE(sequence == "start;exec;done;");
+    REQUIRE(f.get_ready() == 99);
+}
+
+TEST_CASE("resume_on_generic_propagates_exception") {
+    string sequence;
+    auto exec = [&](auto&& task) {
+        sequence += "exec;";
+        task();
+    };
+
+    auto f = [&]() -> future<int> {
+        sequence += "start;";
+        try {
+            (void)co_await resume_on(exec, throwing_awaitable{});
+        } catch (const test_exception& e) {
+            sequence += "catch;";
+            REQUIRE(string(e.what()) == "generic resume_on throw");
+            co_return 1;
+        }
+        co_return 0;
+    }();
+
+    REQUIRE(sequence == "start;exec;catch;");
+    REQUIRE(f.get_ready() == 1);
+}
+
+TEST_CASE("resume_on_generic_suspend_propagates_exception") {
+    test::cooperative_executor coop;
+    string sequence;
+    g_proxy_handle = nullptr;
+
+    auto f = [&]() -> future<int> {
+        sequence += "start;";
+        try {
+            (void)co_await resume_on(coop.executor(), suspend_throwing_awaitable{});
+        } catch (const test_exception& e) {
+            sequence += "catch;";
+            REQUIRE(string(e.what()) == "generic resume_on suspend throw");
+            co_return 1;
+        }
+        co_return 0;
+    }();
+
+    REQUIRE(sequence == "start;");
+    REQUIRE(g_proxy_handle);
+    g_proxy_handle.resume();
+    coop.execute_all();
+
+    REQUIRE(sequence == "start;catch;");
+    REQUIRE(f.get_ready() == 1);
+}
+
+TEST_CASE("resume_on_generic_void_awaitable_suspend_path") {
+    test::cooperative_executor coop;
+    string sequence;
+    g_proxy_handle = nullptr;
+
+    auto f = [&]() -> future<int> {
+        sequence += "start;";
+        co_await resume_on(coop.executor(), manual_complete_void_awaitable{});
+        sequence += "done;";
+        co_return 11;
+    }();
+
+    REQUIRE(sequence == "start;");
+    REQUIRE(g_proxy_handle);
+    g_proxy_handle.resume();
+    coop.execute_all();
+
+    REQUIRE(sequence == "start;done;");
+    REQUIRE(await(std::move(f)) == 11);
+}
+
+TEST_CASE("resume_on_generic_non_controlled_suspend_path") {
+    test::cooperative_executor coop;
+    string sequence;
+    g_proxy_handle = nullptr;
+
+    auto run = [&]() -> detached_test_coro {
+        sequence += "start;";
+        int x = co_await resume_on(coop.executor(), manual_complete_awaitable{});
+        sequence += "done:" + to_string(x) + ";";
+    };
+
+    run();
+    REQUIRE(sequence == "start;");
+    REQUIRE(g_proxy_handle);
+
+    g_proxy_handle.resume();
+    coop.execute_all();
+
+    REQUIRE(sequence == "start;done:7;");
+}
+
+TEST_CASE("resume_on_generic_non_controlled_ready_path") {
+    string sequence;
+    auto exec = [&](auto&& task) {
+        sequence += "exec;";
+        task();
+    };
+
+    auto run = [&]() -> detached_test_coro {
+        sequence += "start;";
+        int x = co_await resume_on(exec, ready_value_awaitable{5});
+        sequence += "done:" + to_string(x) + ";";
+    };
+
+    run();
+    REQUIRE(sequence == "start;exec;done:5;");
+}
+
+TEST_CASE("resume_on_generic_with_cancel") {
+    // Cancellation: reset() drops the future and destroys the coroutine so it never completes.
+    // Uses generic resume_on(executor, awaitable) with a suspending awaitable.
+    test::cooperative_executor coop;
+    string sequence;
+
+    auto f = [&]() -> future<void> {
+        sequence += "start;";
+        co_await resume_on(coop.executor(), manual_complete_awaitable{});
+        sequence += "finish;";
+    }();
+
+    REQUIRE(sequence == "start;");
+    f.reset();
+    g_proxy_handle.resume();
+    coop.execute_all();
+    REQUIRE(sequence == "start;");
+}

--- a/test/future_coroutine_tests.cpp
+++ b/test/future_coroutine_tests.cpp
@@ -438,7 +438,8 @@ TEST_CASE("resume_on_generic_suspend_propagates_exception") {
     REQUIRE(f.get_ready() == 1);
 }
 
-// Minimal repro variant: no [&] capture for sequence; use shared_ptr so coroutine doesn't hold stack ref.
+// Minimal repro variant: no [&] capture for sequence; use shared_ptr so coroutine doesn't hold
+// stack ref.
 TEST_CASE("resume_on_generic_suspend_propagates_exception_no_ref_capture") {
     test::cooperative_executor coop;
     auto sequence = std::make_shared<std::string>();
@@ -544,4 +545,209 @@ TEST_CASE("resume_on_generic_with_cancel") {
     g_proxy_handle.resume();
     coop.execute_all();
     REQUIRE(sequence == "start;");
+}
+
+// --- cancelable(awaitable): resume_on(immediate_executor, …) + stlab::future only ---
+
+TEST_CASE("cancelable_single_co_await_on_suspend_path") {
+    test::cooperative_executor coop;
+    g_proxy_handle = nullptr;
+    g_co_await_invocation_count.store(0);
+
+    auto coro = [&]() -> future<int> {
+        int x = co_await cancelable(co_await_counting_awaitable{});
+        co_return x;
+    };
+    auto f = coro();
+
+    REQUIRE(g_proxy_handle);
+    REQUIRE(g_co_await_invocation_count.load() == 1);
+    g_proxy_handle.resume();
+    coop.execute_all();
+
+    REQUIRE(await(std::move(f)) == 99);
+    REQUIRE(g_co_await_invocation_count.load() == 1);
+}
+
+TEST_CASE("cancelable_completes_after_manual_resume") {
+    test::cooperative_executor coop;
+    g_proxy_handle = nullptr;
+
+    auto coro = [&]() -> future<int> {
+        int x = co_await cancelable(manual_complete_awaitable{});
+        co_return x + 35;
+    };
+    auto f = coro();
+
+    REQUIRE(g_proxy_handle);
+    g_proxy_handle.resume();
+    coop.execute_all();
+
+    REQUIRE(await(std::move(f)) == 42);
+}
+
+TEST_CASE("cancelable_ready_awaitable") {
+    string sequence;
+
+    auto coro = [&]() -> future<int> {
+        sequence += "start;";
+        int x = co_await cancelable(ready_value_awaitable{99});
+        sequence += "done;";
+        co_return x;
+    };
+    auto f = coro();
+
+    REQUIRE(sequence == "start;done;");
+    REQUIRE(f.get_ready() == 99);
+}
+
+TEST_CASE("cancelable_direct_awaiter") {
+    string sequence;
+
+    auto coro = [&]() -> future<void> {
+        sequence += "start;";
+        co_await cancelable(std::suspend_never{});
+        sequence += "done;";
+    };
+    auto f = coro();
+
+    REQUIRE(sequence == "start;done;");
+    (void)await(std::move(f));
+}
+
+TEST_CASE("cancelable_propagates_exception") {
+    string sequence;
+
+    auto coro = [&]() -> future<int> {
+        sequence += "start;";
+        try {
+            (void)co_await cancelable(throwing_awaitable{});
+        } catch (const test_exception& e) {
+            sequence += "catch;";
+            REQUIRE(string(e.what()) == "generic resume_on throw");
+            co_return 1;
+        }
+        co_return 0;
+    };
+    auto f = coro();
+
+    REQUIRE(sequence == "start;catch;");
+    REQUIRE(f.get_ready() == 1);
+}
+
+TEST_CASE("cancelable_suspend_propagates_exception") {
+    test::cooperative_executor coop;
+    string sequence;
+    g_proxy_handle = nullptr;
+
+    auto coro = [&]() -> future<int> {
+        sequence += "start;";
+        try {
+            (void)co_await cancelable(suspend_throwing_awaitable{});
+        } catch (const test_exception& e) {
+            sequence += "catch;";
+            REQUIRE(string(e.what()) == "generic resume_on suspend throw");
+            co_return 1;
+        }
+        co_return 0;
+    };
+    auto f = coro();
+
+    REQUIRE(sequence == "start;");
+    REQUIRE(g_proxy_handle);
+    g_proxy_handle.resume();
+    coop.execute_all();
+
+    REQUIRE(sequence == "start;catch;");
+    REQUIRE(f.get_ready() == 1);
+}
+
+TEST_CASE("cancelable_void_awaitable_suspend_path") {
+    test::cooperative_executor coop;
+    string sequence;
+    g_proxy_handle = nullptr;
+
+    auto coro = [&]() -> future<int> {
+        sequence += "start;";
+        co_await cancelable(manual_complete_void_awaitable{});
+        sequence += "done;";
+        co_return 11;
+    };
+    auto f = coro();
+
+    REQUIRE(sequence == "start;");
+    REQUIRE(g_proxy_handle);
+    g_proxy_handle.resume();
+    coop.execute_all();
+
+    REQUIRE(sequence == "start;done;");
+    REQUIRE(await(std::move(f)) == 11);
+}
+
+TEST_CASE("cancelable_with_cancel") {
+    test::cooperative_executor coop;
+    string sequence;
+
+    auto coro = [&]() -> future<void> {
+        sequence += "start;";
+        co_await cancelable(manual_complete_awaitable{});
+        sequence += "finish;";
+    };
+    auto f = coro();
+
+    REQUIRE(sequence == "start;");
+    f.reset();
+    g_proxy_handle.resume();
+    coop.execute_all();
+    REQUIRE(sequence == "start;");
+}
+
+// --- cancelable(): single shared owner suspends without scheduled resumption ---
+
+TEST_CASE("cancelable_void_unique_suspends_without_resume") {
+    g_proxy_handle = nullptr;
+    string sequence;
+
+    auto coro = [&]() -> future<void> {
+        sequence += "before;";
+        co_await manual_complete_awaitable{};
+        sequence += "between;";
+        co_await cancelable();
+        sequence += "after;";
+        co_return;
+    };
+    auto f = coro();
+
+    REQUIRE(sequence == "before;");
+    REQUIRE(g_proxy_handle);
+    // Drop the consumer handle while suspended at the manual point.
+    f.reset();
+    g_proxy_handle.resume(); // resume
+
+    REQUIRE(sequence == "before;between;");
+}
+
+TEST_CASE("cancelable_void_skips_suspend_when_future_is_shared") {
+    g_proxy_handle = nullptr;
+    string sequence;
+
+    auto coro = [&]() -> future<void> {
+        sequence += "before;";
+        co_await manual_complete_awaitable{};
+        sequence += "between;";
+        co_await cancelable();
+        sequence += "after;";
+        co_return;
+    };
+    auto f = coro();
+    auto g = f;
+
+    REQUIRE(sequence == "before;");
+    REQUIRE(g_proxy_handle);
+    // Drop a consumer handle while suspended at the manual point.
+    // will still continue execution because held by g.
+    f.reset();
+    g_proxy_handle.resume(); // resume
+
+    REQUIRE(sequence == "before;between;after;");
 }


### PR DESCRIPTION
- Introduced new structures for handling `resume_on` with any awaitable.
- Updated existing tests to validate the behavior of the new coroutine features.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes coroutine await/ownership behavior in `future.hpp` by adding a new generic `resume_on` path and new cancellation checkpoints, which could affect scheduling, exception propagation, and coroutine destruction semantics.
> 
> **Overview**
> Adds a new overload `resume_on(executor, awaitable)` that accepts *any* C++ awaitable/awaiter and ensures resumption happens on the provided executor, including for immediately-ready awaitables; this is implemented via generic awaiter detection plus a small proxy coroutine to bridge suspension and capture results/exceptions.
> 
> Introduces `cancelable(awaitable)` (immediate-executor resume with `stlab::future`-coroutine-only cancellation semantics) and a `cancelable()` checkpoint that destroys the coroutine when the last `future` reference is gone; the `future` promise `await_transform` is extended to support these new awaiters.
> 
> Updates coroutine tests to cover generic awaitables (ready/suspending, void/non-void, exceptions, single `operator co_await` invocation, and cancellation), and tweaks CI Windows setup to use `TheMrMilchmann/setup-msvc-dev@v4` with `arch: x64`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 247233f9bafc457c83d771220dddd60dbd5410d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->